### PR TITLE
fix wrong charactor in chinese doc

### DIFF
--- a/docs/zh-cn/mutations.md
+++ b/docs/zh-cn/mutations.md
@@ -39,7 +39,7 @@ mutations: {
 }
 ```
 ``` js
-vuex.dispatch('INCREMENT', 10)
+store.dispatch('INCREMENT', 10)
 ```
 
 这里的 `10` 会紧跟着 `state` 作为第二个参数被传递到 mutation handler. 所有额外的参数被称为该 mutation 的 payload.


### PR DESCRIPTION
```
vuex.dispatch('INCREMENT', 10) -> store.dispatch('INCREMENT', 10)
```
