### PR TITLE
fix naming consistency in documentation example

### DIFF
--- a/docs/en/actions.md
+++ b/docs/en/actions.md
@@ -133,4 +133,4 @@ actions: {
 }
 ```
 
-Again, all the component needs to do to perform the entire checkout is just calling `vuex.actions.checkout(products)`.
+Again, all the component needs to do to perform the entire checkout is just calling `store.actions.checkout(products)`.


### PR DESCRIPTION
`vuex` -> `store`