### PR TITLE
Close markdown code block

### DIFF
--- a/docs/en/getters.md
+++ b/docs/en/getters.md
@@ -38,6 +38,7 @@ export default {
     filteredTodos
   }
 }
+```
 
 For an actual example, check out the [Shopping Cart Example](https://github.com/vuejs/vuex/tree/master/examples/shopping-cart).
 For an actual example with hot reload API, check out the [Counter Hot Example](https://github.com/vuejs/vuex/tree/master/examples/counter-hot).


### PR DESCRIPTION
Add missing backticks at the end of the getters documentation. 