### PR TITLE
concepts.md store - "mutations" before "actions"

### DIFF
--- a/docs/en/concepts.md
+++ b/docs/en/concepts.md
@@ -25,8 +25,8 @@ import Vuex from 'vuex'
 
 const store = new Vuex.Store({
   state: { ... },
-  actions: { ... },
   mutations: { ... },
+  actions: { ... },
   getters: { ... }
 })
 ```


### PR DESCRIPTION
A suggestion. Just to make it "synchronized" to the remaining of the guide, where we learn "mutations" before "actions".