### PR TITLE
Add an option to automatically create actions for mutations

### DIFF
--- a/examples/todomvc/components/App.vue
+++ b/examples/todomvc/components/App.vue
@@ -66,9 +66,13 @@ export default {
       todos: state => state.todos
     },
     actions: {
-      addTodo,
       toggleAll,
       clearCompleted
+    },
+    auto: function (store) {
+      return {
+        todoActions: store
+      }
     }
   },
   data () {
@@ -92,7 +96,7 @@ export default {
     tryAddTodo (e) {
       var text = e.target.value
       if (text.trim()) {
-        this.addTodo(text)
+        this.todoActions.addTodo(text)
       }
       e.target.value = ''
     }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { mergeObjects, deepClone, getWatcher } from './util'
+import { mergeObjects, deepClone, getWatcher, mutatorNameToCamelCase } from './util'
 import devtoolMiddleware from './middlewares/devtool'
 import override from './override'
 
@@ -49,6 +49,7 @@ class Store {
     this._setupModuleState(state, modules)
     this._setupModuleMutations(modules)
     this._setupMiddlewares(middlewares, state)
+    this._setupAuto ()
     // add extra warnings in strict mode
     if (strict) {
       this._setupMutationCheck()
@@ -209,6 +210,16 @@ class Store {
       }
     }, { deep: true, sync: true })
     /* eslint-enable no-new */
+  }
+
+  _setupAuto () {
+    this._auto = {}
+    for (let key in this._mutations) {
+      var camelCaseKey = mutatorNameToCamelCase(key)
+      this._auto[camelCaseKey] = ({ dispatch }, ...args) => {
+        dispatch(key, ...args)
+      }
+    }
   }
 
   /**

--- a/src/override.js
+++ b/src/override.js
@@ -27,7 +27,7 @@ export default function (Vue) {
           'provide the store option in your root component.'
         )
       }
-      let { state, getters, actions } = vuex
+      let { state, getters, actions, auto } = vuex
       // handle deprecated state option
       if (state && !getters) {
         console.warn(
@@ -48,6 +48,22 @@ export default function (Vue) {
         options.methods = options.methods || {}
         for (let key in actions) {
           options.methods[key] = makeBoundAction(actions[key], this.$store)
+        }
+      }
+
+      if (auto) {
+        options.methods = options.methods || {}
+        // The auto function 'selects' the store
+        // by returning a key-value object [ key => store ]
+        var selected = auto(this.$store)
+        for (let selectionKey in selected) {
+          var autoStore = selected[selectionKey]
+          // create an object to hold all the bound actions
+          var autoActions = {}
+          for (let autoKey in autoStore._auto) {
+            autoActions[autoKey] = makeBoundAction(autoStore._auto[autoKey], autoStore)
+          }
+          this[selectionKey] = autoActions
         }
       }
     }

--- a/src/util.js
+++ b/src/util.js
@@ -48,6 +48,23 @@ export function deepClone (obj) {
   }
 }
 
+export function mutatorNameToCamelCase (name) {
+  var len = name.length
+  var newName = ''
+  for (var i = 0; i < len; i++) {
+    if (name[i] === '_') {
+      continue
+    }
+    if (name[i - 1] && name[i - 1] === '_') {
+      newName += name[i].toUpperCase()
+    } else {
+      newName += name[i].toLowerCase()
+    }
+  }
+
+  return newName
+}
+
 /**
  * Hacks to get access to Vue internals.
  * Maybe we should expose these...


### PR DESCRIPTION
In some apps (for example todomvc itself) there's a use case for quickly
and easily calling a mutation from the controller.

This reduces the effort by automatically creating simple pass-through actions
which automatically camel-case the mutation name and create a function.

Here's my rationale behind this patch: 

http://forum.vuejs.org/topic/3438/vuex-tiny-feedback-suggestion