### PR TITLE
Update store with default export to match later docs and examples

### DIFF
--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -25,7 +25,7 @@ const mutations = {
   }
 }
 
-const store = new Vuex.Store({
+export default new Vuex.Store({
   state,
   mutations
 })


### PR DESCRIPTION
It wasn't immediately apparent to me when going along with the docs that the Vuex instance should be the object exported from the store. After looking at the examples and reading on in the docs it looks like this is the usual intent. Might make sense to add that to the Getting Started page?