### PR TITLE
add one important missing line

### DIFF
--- a/docs/zh-cn/state.md
+++ b/docs/zh-cn/state.md
@@ -36,7 +36,9 @@ computed: {
 
   var app = new Vue({
     el: '#app',
-    // 使用 "store" 来配置，并会在全部的子组件中注入 store 实例,
+    // 使用 “store” 选项来配置 store 实例
+    // 并会在全部的子组件中注入 store 实例
+    store,
     components: {
       MyComponent
     }


### PR DESCRIPTION
屏幕不够宽，对照翻译的时候文字折行了，误删了一行重要的示例代码。—— 《论几个屏幕才够用》