### PR TITLE
console.warn when getter is not a function

### DIFF
--- a/src/override.js
+++ b/src/override.js
@@ -74,12 +74,16 @@ export default function (Vue) {
    */
 
   function defineVuexGetter (vm, key, getter) {
-    Object.defineProperty(vm, key, {
-      enumerable: true,
-      configurable: true,
-      get: makeComputedGetter(vm.$store, getter),
-      set: setter
-    })
+    if (typeof getter !== 'function') {
+      console.warn(`[vuex] Getter bound to key 'vuex.getters.${key}' is not a function.`)
+    } else {
+      Object.defineProperty(vm, key, {
+        enumerable: true,
+        configurable: true,
+        get: makeComputedGetter(vm.$store, getter),
+        set: setter
+      })
+    }
   }
 
   /**
@@ -95,6 +99,7 @@ export default function (Vue) {
 
   function makeComputedGetter (store, getter) {
     const id = store._getterCacheId
+
     // cached
     if (getter[id]) {
       return getter[id]

--- a/test/unit/test.js
+++ b/test/unit/test.js
@@ -464,4 +464,30 @@ describe('Vuex', () => {
     expect(console.warn).to.have.been.calledWith('[vuex] Action bound to key \'vuex.actions.test\' is not a function.')
     console.warn.restore()
   })
+
+  it('console.warn when getter is not a function', function () {
+    const store = new Vuex.Store({
+      state: {
+        a: 1
+      },
+      mutations: {
+        [TEST] (state, amount) {
+          state.a += amount
+        }
+      }
+    })
+    sinon.spy(console, 'warn')
+
+    new Vue({
+      store,
+      vuex: {
+        getters: {
+          test: undefined
+        }
+      }
+    })
+
+    expect(console.warn).to.have.been.calledWith('[vuex] Getter bound to key \'vuex.getters.test\' is not a function.')
+    console.warn.restore()
+  })
 })


### PR DESCRIPTION
Someday when I was refactoring my code, I changed some getters name. All things crash with unknown errors. After I digg into the code, and find the reason, I made this PR for you.