### PR TITLE
Changing example filename in tutorial doc

### DIFF
--- a/docs/en/tutorial.md
+++ b/docs/en/tutorial.md
@@ -121,7 +121,7 @@ Edit `components/App.vue` and add the store.
 
 ```js
 import Display from './Display.vue'
-import Increment from './IncrementButton.vue'
+import Increment from './Increment.vue'
 import store from '../vuex/store' // import the store we just created
 
 export default {


### PR DESCRIPTION
The rest of the page used Increment.vue, but this one line uses IncrementButton.vue when referring to the same file