### PR TITLE
Update babel-runtime version

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "babel-preset-es2015": "^6.1.18",
     "babel-preset-es2015-rollup": "^1.1.1",
     "babel-preset-stage-2": "^6.1.18",
-    "babel-runtime": "^5.8.0",
+    "babel-runtime": "^6.0.0",
     "casperjs": "^1.1.0-beta5",
     "chai": "^3.4.1",
     "css-loader": "^0.23.1",


### PR DESCRIPTION

In `npm install`, I got below error.
So I update ` babel-runtime`. And fixed error.

```
~/W/vuex git:master ❯❯❯ npm install                                               ◼
npm ERR! Darwin 14.5.0
npm ERR! argv "/usr/local/Cellar/node/4.2.1/bin/node" "/usr/local/bin/npm" "install"
npm ERR! node v4.2.1
npm ERR! npm  v2.14.7
npm ERR! code EPEERINVALID

npm ERR! peerinvalid The package babel-runtime@5.8.38 does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer vue-loader@8.5.2 wants babel-runtime@^6.0.0
```