### PR TITLE
Removed 'actions' from Vuex.Store constructor

### DIFF
--- a/docs/en/mutations.md
+++ b/docs/en/mutations.md
@@ -130,7 +130,6 @@ import { SOME_MUTATION } from './mutation-types'
 
 const store = new Vuex.Store({
   state: { ... },
-  actions: { ... },
   mutations: {
     // we can use the ES2015 computed property name feature
     // to use a constant as the function name


### PR DESCRIPTION
This is the only place in the documentation where `actions` are passed in to `new Vuex.Store`. There is no explanation for the discrepancy (i.e. all other documentation, including the API and the next page dedicated to actions, indicate those should be passed to the Vue constructor.