### PR TITLE
Allow nested modules

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 import {
-  mergeObjects, deepClone,
-  isModuleProperty, getNestedState,
-  getWatcher
+  mergeObjects, deepClone, isObject,
+  getNestedState, getWatcher
 } from './util'
 import devtoolMiddleware from './middlewares/devtool'
 import override from './override'
@@ -144,16 +143,16 @@ class Store {
    */
 
   _setupModuleState (state, modules) {
-    Object.keys(modules).forEach(key => {
-      if (isModuleProperty(key)) return
+    if (!isObject(modules)) return
 
+    Object.keys(modules).forEach(key => {
       const module = modules[key]
 
       // set this module's state
       Vue.set(state, key, module.state || {})
 
       // retrieve nested modules
-      this._setupModuleState(state[key], module)
+      this._setupModuleState(state[key], module.modules)
     })
   }
 
@@ -184,14 +183,14 @@ class Store {
    */
 
   _createModuleMutations (modules, nestedKeys) {
-    return Object.keys(modules).map(key => {
-      if (isModuleProperty(key)) return {}
+    if (!isObject(modules)) return []
 
+    return Object.keys(modules).map(key => {
       const module = modules[key]
       const newNestedKeys = nestedKeys.concat(key)
 
       // retrieve nested modules
-      const nestedMutations = this._createModuleMutations(module, newNestedKeys)
+      const nestedMutations = this._createModuleMutations(module.modules, newNestedKeys)
 
       if (!module || !module.mutations) {
         return mergeObjects(nestedMutations)

--- a/src/util.js
+++ b/src/util.js
@@ -49,16 +49,14 @@ export function deepClone (obj) {
 }
 
 /**
- * Detect whether the given object is nested module or not.
- * An object have not both `state` and `mutations` is nested module.
+ * Detect whether the given key is a module property or not.
  *
  * @param {*} obj
  * @return {Boolean}
  */
 
-export function isNestedModule (module) {
-  return module !== null && typeof module === 'object' &&
-    !('state' in module && 'mutations' in module)
+export function isModuleProperty (key) {
+  return key === 'state' || key === 'mutations'
 }
 
 /**

--- a/src/util.js
+++ b/src/util.js
@@ -49,6 +49,30 @@ export function deepClone (obj) {
 }
 
 /**
+ * Detect whether the given object is nested module or not.
+ * An object have not both `state` and `mutations` is nested module.
+ *
+ * @param {*} obj
+ * @return {Boolean}
+ */
+
+export function isNestedModule (module) {
+  return module !== null && typeof module === 'object' &&
+    !('state' in module && 'mutations' in module)
+}
+
+/**
+ * Get state sub tree by given keys.
+ *
+ * @param {Object} state
+ * @param {Array<String>} nestedKeys
+ * @return {Object}
+ */
+export function getNestedState (state, nestedKeys) {
+  return nestedKeys.reduce((state, key) => state[key], state)
+}
+
+/**
  * Hacks to get access to Vue internals.
  * Maybe we should expose these...
  */

--- a/src/util.js
+++ b/src/util.js
@@ -49,14 +49,14 @@ export function deepClone (obj) {
 }
 
 /**
- * Detect whether the given key is a module property or not.
+ * Check whether the given value is Object or not
  *
  * @param {*} obj
  * @return {Boolean}
  */
 
-export function isModuleProperty (key) {
-  return key === 'state' || key === 'mutations'
+export function isObject (obj) {
+  return obj !== null && typeof obj === 'object'
 }
 
 /**

--- a/src/util.js
+++ b/src/util.js
@@ -13,9 +13,9 @@ export function mergeObjects (arr) {
         // allow multiple mutation objects to contain duplicate
         // handlers for the same mutation type
         if (Array.isArray(existing)) {
-          existing.push(obj[key])
+          prev[key] = existing.concat(obj[key])
         } else {
-          prev[key] = [prev[key], obj[key]]
+          prev[key] = [existing].concat(obj[key])
         }
       } else {
         prev[key] = obj[key]

--- a/test/unit/test.js
+++ b/test/unit/test.js
@@ -65,20 +65,27 @@ describe('Vuex', () => {
       },
       mutations,
       modules: {
-        one: {
-          state: { a: 2 },
-          mutations
+        nested: {
+          one: {
+            state: { a: 2 },
+            mutations
+          },
+          two: {
+            state: { a: 3 },
+            mutations
+          }
         },
-        two: {
-          state: { a: 3 },
+        three: {
+          state: { a: 4 },
           mutations
         }
       }
     })
     store.dispatch(TEST, 1)
     expect(store.state.a).to.equal(2)
-    expect(store.state.one.a).to.equal(3)
-    expect(store.state.two.a).to.equal(4)
+    expect(store.state.nested.one.a).to.equal(3)
+    expect(store.state.nested.two.a).to.equal(4)
+    expect(store.state.three.a).to.equal(5)
   })
 
   it('hot reload', function () {
@@ -93,20 +100,27 @@ describe('Vuex', () => {
       },
       mutations,
       modules: {
-        one: {
-          state: { a: 2 },
-          mutations
+        nested: {
+          one: {
+            state: { a: 2 },
+            mutations
+          },
+          two: {
+            state: { a: 3 },
+            mutations
+          }
         },
-        two: {
-          state: { a: 3 },
+        three: {
+          state: { a: 4 },
           mutations
         }
       }
     })
     store.dispatch(TEST, 1)
     expect(store.state.a).to.equal(2)
-    expect(store.state.one.a).to.equal(3)
-    expect(store.state.two.a).to.equal(4)
+    expect(store.state.nested.one.a).to.equal(3)
+    expect(store.state.nested.two.a).to.equal(4)
+    expect(store.state.three.a).to.equal(5)
 
     // hot reload only root mutations
     store.hotUpdate({
@@ -118,22 +132,33 @@ describe('Vuex', () => {
     })
     store.dispatch(TEST, 1)
     expect(store.state.a).to.equal(1) // only root mutation updated
-    expect(store.state.one.a).to.equal(4)
-    expect(store.state.two.a).to.equal(5)
+    expect(store.state.nested.one.a).to.equal(4)
+    expect(store.state.nested.two.a).to.equal(5)
+    expect(store.state.three.a).to.equal(6)
 
     // hot reload modules
     store.hotUpdate({
       modules: {
-        one: {
-          state: { a: 234 },
-          mutations: {
-            [TEST] (state, n) {
-              state.a += n
+        nested: {
+          one: {
+            state: { a: 234 },
+            mutations: {
+              [TEST] (state, n) {
+                state.a += n
+              }
+            }
+          },
+          two: {
+            state: { a: 345 },
+            mutations: {
+              [TEST] (state, n) {
+                state.a -= n
+              }
             }
           }
         },
-        two: {
-          state: { a: 345 },
+        three: {
+          state: { a: 456 },
           mutations: {
             [TEST] (state, n) {
               state.a -= n
@@ -144,8 +169,9 @@ describe('Vuex', () => {
     })
     store.dispatch(TEST, 2)
     expect(store.state.a).to.equal(2)
-    expect(store.state.one.a).to.equal(6) // should not reload initial state
-    expect(store.state.two.a).to.equal(3) // should not reload initial state
+    expect(store.state.nested.one.a).to.equal(6) // should not reload initial state
+    expect(store.state.nested.two.a).to.equal(3) // should not reload initial state
+    expect(store.state.three.a).to.equal(4) // should not reload initial state
 
     // hot reload all
     store.hotUpdate({
@@ -155,16 +181,26 @@ describe('Vuex', () => {
         }
       },
       modules: {
-        one: {
-          state: { a: 234 },
-          mutations: {
-            [TEST] (state, n) {
-              state.a = n
+        nested: {
+          one: {
+            state: { a: 234 },
+            mutations: {
+              [TEST] (state, n) {
+                state.a = n
+              }
+            }
+          },
+          two: {
+            state: { a: 345 },
+            mutations: {
+              [TEST] (state, n) {
+                state.a = n
+              }
             }
           }
         },
-        two: {
-          state: { a: 345 },
+        three: {
+          state: { a: 456 },
           mutations: {
             [TEST] (state, n) {
               state.a = n
@@ -175,8 +211,9 @@ describe('Vuex', () => {
     })
     store.dispatch(TEST, 3)
     expect(store.state.a).to.equal(-1)
-    expect(store.state.one.a).to.equal(3)
-    expect(store.state.two.a).to.equal(3)
+    expect(store.state.nested.one.a).to.equal(3)
+    expect(store.state.nested.two.a).to.equal(3)
+    expect(store.state.three.a).to.equal(3)
   })
 
   it('middleware', function () {

--- a/test/unit/test.js
+++ b/test/unit/test.js
@@ -68,18 +68,22 @@ describe('Vuex', () => {
         nested: {
           state: { a: 2 },
           mutations,
-          one: {
-            state: { a: 3 },
-            mutations
-          },
-          nested: {
-            two: {
-              state: { a: 4 },
+          modules: {
+            one: {
+              state: { a: 3 },
               mutations
             },
-            three: {
-              state: { a: 5 },
-              mutations
+            nested: {
+              modules: {
+                two: {
+                  state: { a: 4 },
+                  mutations
+                },
+                three: {
+                  state: { a: 5 },
+                  mutations
+                }
+              }
             }
           }
         },
@@ -113,18 +117,22 @@ describe('Vuex', () => {
         nested: {
           state: { a: 2 },
           mutations,
-          one: {
-            state: { a: 3 },
-            mutations
-          },
-          nested: {
-            two: {
-              state: { a: 4 },
+          modules: {
+            one: {
+              state: { a: 3 },
               mutations
             },
-            three: {
-              state: { a: 5 },
-              mutations
+            nested: {
+              modules: {
+                two: {
+                  state: { a: 4 },
+                  mutations
+                },
+                three: {
+                  state: { a: 5 },
+                  mutations
+                }
+              }
             }
           }
         },
@@ -164,18 +172,22 @@ describe('Vuex', () => {
         nested: {
           state: { a: 234 },
           mutations,
-          one: {
-            state: { a: 345 },
-            mutations
-          },
-          nested: {
-            two: {
-              state: { a: 456 },
+          modules: {
+            one: {
+              state: { a: 345 },
               mutations
             },
-            three: {
-              state: { a: 567 },
-              mutations
+            nested: {
+              modules: {
+                two: {
+                  state: { a: 456 },
+                  mutations
+                },
+                three: {
+                  state: { a: 567 },
+                  mutations
+                }
+              }
             }
           }
         },
@@ -208,28 +220,32 @@ describe('Vuex', () => {
               state.a += n
             }
           },
-          one: {
-            state: { a: 345 },
-            mutations: {
-              [TEST] (state, n) {
-                state.a += n
-              }
-            }
-          },
-          nested: {
-            two: {
-              state: { a: 456 },
+          modules: {
+            one: {
+              state: { a: 345 },
               mutations: {
                 [TEST] (state, n) {
                   state.a += n
                 }
               }
             },
-            three: {
-              state: { a: 567 },
-              mutations: {
-                [TEST] (state, n) {
-                  state.a -= n
+            nested: {
+              modules: {
+                two: {
+                  state: { a: 456 },
+                  mutations: {
+                    [TEST] (state, n) {
+                      state.a += n
+                    }
+                  }
+                },
+                three: {
+                  state: { a: 567 },
+                  mutations: {
+                    [TEST] (state, n) {
+                      state.a -= n
+                    }
+                  }
                 }
               }
             }

--- a/test/unit/test.js
+++ b/test/unit/test.js
@@ -66,26 +66,36 @@ describe('Vuex', () => {
       mutations,
       modules: {
         nested: {
+          state: { a: 2 },
+          mutations,
           one: {
-            state: { a: 2 },
-            mutations
-          },
-          two: {
             state: { a: 3 },
             mutations
+          },
+          nested: {
+            two: {
+              state: { a: 4 },
+              mutations
+            },
+            three: {
+              state: { a: 5 },
+              mutations
+            }
           }
         },
-        three: {
-          state: { a: 4 },
+        four: {
+          state: { a: 6 },
           mutations
         }
       }
     })
     store.dispatch(TEST, 1)
     expect(store.state.a).to.equal(2)
-    expect(store.state.nested.one.a).to.equal(3)
-    expect(store.state.nested.two.a).to.equal(4)
-    expect(store.state.three.a).to.equal(5)
+    expect(store.state.nested.a).to.equal(3)
+    expect(store.state.nested.one.a).to.equal(4)
+    expect(store.state.nested.nested.two.a).to.equal(5)
+    expect(store.state.nested.nested.three.a).to.equal(6)
+    expect(store.state.four.a).to.equal(7)
   })
 
   it('hot reload', function () {
@@ -101,26 +111,36 @@ describe('Vuex', () => {
       mutations,
       modules: {
         nested: {
+          state: { a: 2 },
+          mutations,
           one: {
-            state: { a: 2 },
-            mutations
-          },
-          two: {
             state: { a: 3 },
             mutations
+          },
+          nested: {
+            two: {
+              state: { a: 4 },
+              mutations
+            },
+            three: {
+              state: { a: 5 },
+              mutations
+            }
           }
         },
-        three: {
-          state: { a: 4 },
+        four: {
+          state: { a: 6 },
           mutations
         }
       }
     })
     store.dispatch(TEST, 1)
     expect(store.state.a).to.equal(2)
-    expect(store.state.nested.one.a).to.equal(3)
-    expect(store.state.nested.two.a).to.equal(4)
-    expect(store.state.three.a).to.equal(5)
+    expect(store.state.nested.a).to.equal(3)
+    expect(store.state.nested.one.a).to.equal(4)
+    expect(store.state.nested.nested.two.a).to.equal(5)
+    expect(store.state.nested.nested.three.a).to.equal(6)
+    expect(store.state.four.a).to.equal(7)
 
     // hot reload only root mutations
     store.hotUpdate({
@@ -132,46 +152,46 @@ describe('Vuex', () => {
     })
     store.dispatch(TEST, 1)
     expect(store.state.a).to.equal(1) // only root mutation updated
-    expect(store.state.nested.one.a).to.equal(4)
-    expect(store.state.nested.two.a).to.equal(5)
-    expect(store.state.three.a).to.equal(6)
+    expect(store.state.nested.a).to.equal(4)
+    expect(store.state.nested.one.a).to.equal(5)
+    expect(store.state.nested.nested.two.a).to.equal(6)
+    expect(store.state.nested.nested.three.a).to.equal(7)
+    expect(store.state.four.a).to.equal(8)
 
     // hot reload modules
     store.hotUpdate({
       modules: {
         nested: {
+          state: { a: 234 },
+          mutations,
           one: {
-            state: { a: 234 },
-            mutations: {
-              [TEST] (state, n) {
-                state.a += n
-              }
-            }
-          },
-          two: {
             state: { a: 345 },
-            mutations: {
-              [TEST] (state, n) {
-                state.a -= n
-              }
+            mutations
+          },
+          nested: {
+            two: {
+              state: { a: 456 },
+              mutations
+            },
+            three: {
+              state: { a: 567 },
+              mutations
             }
           }
         },
-        three: {
-          state: { a: 456 },
-          mutations: {
-            [TEST] (state, n) {
-              state.a -= n
-            }
-          }
+        four: {
+          state: { a: 678 },
+          mutations
         }
       }
     })
     store.dispatch(TEST, 2)
     expect(store.state.a).to.equal(2)
-    expect(store.state.nested.one.a).to.equal(6) // should not reload initial state
-    expect(store.state.nested.two.a).to.equal(3) // should not reload initial state
-    expect(store.state.three.a).to.equal(4) // should not reload initial state
+    expect(store.state.nested.a).to.equal(6) // should not reload initial state
+    expect(store.state.nested.one.a).to.equal(7) // should not reload initial state
+    expect(store.state.nested.nested.two.a).to.equal(8) // should not reload initial state
+    expect(store.state.nested.nested.three.a).to.equal(9) // should not reload initial state
+    expect(store.state.four.a).to.equal(10) // should not reload initial state
 
     // hot reload all
     store.hotUpdate({
@@ -182,28 +202,44 @@ describe('Vuex', () => {
       },
       modules: {
         nested: {
-          one: {
-            state: { a: 234 },
-            mutations: {
-              [TEST] (state, n) {
-                state.a = n
-              }
+          state: { a: 234 },
+          mutations: {
+            [TEST] (state, n) {
+              state.a += n
             }
           },
-          two: {
+          one: {
             state: { a: 345 },
             mutations: {
               [TEST] (state, n) {
-                state.a = n
+                state.a += n
+              }
+            }
+          },
+          nested: {
+            two: {
+              state: { a: 456 },
+              mutations: {
+                [TEST] (state, n) {
+                  state.a += n
+                }
+              }
+            },
+            three: {
+              state: { a: 567 },
+              mutations: {
+                [TEST] (state, n) {
+                  state.a -= n
+                }
               }
             }
           }
         },
-        three: {
-          state: { a: 456 },
+        four: {
+          state: { a: 678 },
           mutations: {
             [TEST] (state, n) {
-              state.a = n
+              state.a -= n
             }
           }
         }
@@ -211,9 +247,11 @@ describe('Vuex', () => {
     })
     store.dispatch(TEST, 3)
     expect(store.state.a).to.equal(-1)
-    expect(store.state.nested.one.a).to.equal(3)
-    expect(store.state.nested.two.a).to.equal(3)
-    expect(store.state.three.a).to.equal(3)
+    expect(store.state.nested.a).to.equal(9)
+    expect(store.state.nested.one.a).to.equal(10)
+    expect(store.state.nested.nested.two.a).to.equal(11)
+    expect(store.state.nested.nested.three.a).to.equal(6)
+    expect(store.state.four.a).to.equal(7)
   })
 
   it('middleware', function () {


### PR DESCRIPTION
This PR fixes #185, allows to define nested modules like the following code.
Properties does not belongs to `state` or `mutations` key are treated as nested modules.

```js
const store = new Vuex.Store({
  modules: {
    nested: {
      moduleA: {
        state: {...},
        mutations: {...}
      },
      moduleB: {
        state: {...},
        mutations: {...}
      }
    },
    moduleC: {
      state: {...},
      mutations: {...}
    }
  }
})

console.log(store.state.nested.moduleA)
console.log(store.state.nested.moduleB)
console.log(store.state.moduleC)
```
