### PR TITLE
Modify type files to external module definition format to publish them via npm

### DIFF
--- a/logger.d.ts
+++ b/logger.d.ts
@@ -1,0 +1,14 @@
+/**
+ * Types for the logger plugin.
+ * This file must be put alongside the JavaScript file of the logger.
+ */
+
+import { MutationObject, Plugin } from './types/index'
+
+export interface LoggerOption<S> {
+  collapsed?: boolean;
+  transformer?: (state: S) => any;
+  mutationTransformer?: (mutation: MutationObject<any>) => any;
+}
+
+export default function createLogger<S>(option: LoggerOption<S>): Plugin<S>;

--- a/package.json
+++ b/package.json
@@ -3,10 +3,14 @@
   "version": "1.0.0-rc.2",
   "description": "state management for Vue.js",
   "main": "dist/vuex.js",
+  "typings": "types/index.d.ts",
   "files": [
     "dist",
     "src",
-    "logger.js"
+    "types/index.d.ts",
+    "types/vue.d.ts",
+    "logger.js",
+    "logger.d.ts"
   ],
   "scripts": {
     "counter": "cd examples/counter && webpack-dev-server --inline --hot --config ../webpack.shared.config.js",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,93 +1,66 @@
-declare namespace Vuex {
-  class Store<S> {
-    constructor(options: StoreOption<S>);
+import './vue'
 
-    state: S;
+export class Store<S> {
+  constructor(options: StoreOption<S>);
 
-    dispatch(mutationName: string, ...args: any[]): void;
-    dispatch<P>(mutation: MutationObject<P>): void;
+  state: S;
 
-    replaceState(state: S): void;
+  dispatch(mutationName: string, ...args: any[]): void;
+  dispatch<P>(mutation: MutationObject<P>): void;
 
-    watch<T>(getter: Getter<S, T>, cb: (value: T) => void, options?: WatchOption): void;
+  replaceState(state: S): void;
 
-    hotUpdate(options: {
-      mutations?: MutationTree<S>;
-      modules?: ModuleTree;
-    }): void;
+  watch<T>(getter: Getter<S, T>, cb: (value: T) => void, options?: WatchOption): void;
 
-    subscribe(cb: (mutation: MutationObject<any>, state: S) => void): () => void;
-  }
-
-  function install(Vue: vuejs.VueStatic): void;
-
-  interface StoreOption<S> {
-    state?: S;
+  hotUpdate(options: {
     mutations?: MutationTree<S>;
     modules?: ModuleTree;
-    plugins?: Plugin<S>[];
-    strict?: boolean;
-  }
+  }): void;
 
-  type Getter<S, T> = (state: S) => T;
-  type Action<S> = (store: Store<S>, ...args: any[]) => any;
-  type Mutation<S> = (state: S, ...args: any[]) => void;
-  type Plugin<S> = (store: Store<S>) => void;
-
-  interface MutationTree<S> {
-    [key: string]: Mutation<S>;
-  }
-
-  interface MutationObject<P> {
-    type: string;
-    silent?: boolean;
-    payload?: P;
-  }
-
-  interface Module<S> {
-    state?: S;
-    mutations?: MutationTree<S>;
-    modules?: ModuleTree;
-  }
-
-  interface ModuleTree {
-    [key: string]: Module<any>;
-  }
-
-  interface ComponentOption<S> {
-    getters: { [key: string]: Getter<S, any> };
-    actions: { [key: string]: Action<S> };
-  }
-
-  interface WatchOption {
-    deep?: boolean;
-    immidiate?: boolean;
-  }
-
-  function createLogger<S>(option: LoggerOption<S>): Plugin<S>;
-
-  interface LoggerOption<S> {
-    collapsed?: boolean;
-    transformer?: (state: S) => any;
-    mutationTransformer?: (mutation: MutationObject<any>) => any;
-  }
+  subscribe(cb: (mutation: MutationObject<any>, state: S) => void): () => void;
 }
 
-declare namespace vuejs {
-  interface ComponentOption {
-    vuex?: Vuex.ComponentOption<any>;
-    store?: Vuex.Store<any>;
-  }
+export function install(Vue: vuejs.VueStatic): void;
 
-  interface Vue {
-    $store?: Vuex.Store<any>;
-  }
+export interface StoreOption<S> {
+  state?: S;
+  mutations?: MutationTree<S>;
+  modules?: ModuleTree;
+  plugins?: Plugin<S>[];
+  strict?: boolean;
 }
 
-declare module 'vuex' {
-  export = Vuex
+type Getter<S, T> = (state: S) => T;
+type Action<S> = (store: Store<S>, ...args: any[]) => any;
+type Mutation<S> = (state: S, ...args: any[]) => void;
+type Plugin<S> = (store: Store<S>) => void;
+
+export interface MutationTree<S> {
+  [key: string]: Mutation<S>;
 }
 
-declare module 'vuex/logger' {
-  export default Vuex.createLogger;
+export interface MutationObject<P> {
+  type: string;
+  silent?: boolean;
+  payload?: P;
+}
+
+export interface Module<S> {
+  state?: S;
+  mutations?: MutationTree<S>;
+  modules?: ModuleTree;
+}
+
+export interface ModuleTree {
+  [key: string]: Module<any>;
+}
+
+export interface VuexComponentOption<S> {
+  getters: { [key: string]: Getter<S, any> };
+  actions: { [key: string]: Action<S> };
+}
+
+export interface WatchOption {
+  deep?: boolean;
+  immidiate?: boolean;
 }

--- a/types/test/index.ts
+++ b/types/test/index.ts
@@ -1,6 +1,6 @@
 import * as Vue from 'vue';
-import * as Vuex from 'vuex';
-import createLogger from 'vuex/logger';
+import * as Vuex from '../index';
+import createLogger from '../../logger';
 
 Vue.use(Vuex);
 

--- a/types/test/tsconfig.json
+++ b/types/test/tsconfig.json
@@ -7,6 +7,8 @@
   "files": [
     "index.ts",
     "../index.d.ts",
+    "../../logger.d.ts",
+    "../vue.d.ts",
     "../typings/index.d.ts"
   ]
 }

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -6,6 +6,8 @@
   },
   "files": [
     "index.d.ts",
+    "../logger.d.ts",
+    "vue.d.ts",
     "typings/index.d.ts"
   ]
 }

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -1,0 +1,18 @@
+/**
+ * Extends interfaces in Vue.js
+ */
+
+import { VuexComponentOption, Store } from './index'
+
+declare global {
+  namespace vuejs {
+    interface ComponentOption {
+      vuex?: VuexComponentOption<any>;
+      store?: Store<any>;
+    }
+
+    interface Vue {
+      $store?: Store<any>;
+    }
+  }
+}


### PR DESCRIPTION
I had send PR to `typings/registry` to register types of Vuex, but it's not accepted and some advices are given. (https://github.com/typings/registry/pull/599)

I rewrote the type files in external module definition format and divide to three files.
We can publish the types via npm without register typings by this modification.

- `/types/index.d.ts` is the types of Vuex
- `/logger.d.ts` is the types of logger module (`'vuex/logger'`)
  - It must be put alongside the actual JS file to enable to import by writing `import createLogger from 'vuex/logger'`.
- `/types/vue.d.ts` is the type extensions for Vue.js (Component options and instance property for Vuex)
