### PR TITLE
Allow to register module getters dynamically

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ class Store {
     this._committing = false
     this._actions = Object.create(null)
     this._mutations = Object.create(null)
-    this._getters = Object.create(null)
+    this._wrappedGetters = Object.create(null)
     this._subscribers = []
     this._pendingActions = []
 
@@ -70,7 +70,7 @@ class Store {
 
     initModule(this, path, module, hot)
 
-    initStoreVM(this, this.state, this._getters)
+    initStoreVM(this, this.state, this._wrappedGetters)
 
     this._committing = false
   }
@@ -175,7 +175,7 @@ class Store {
   hotUpdate (newOptions) {
     this._actions = Object.create(null)
     this._mutations = Object.create(null)
-    this._getters = Object.create(null)
+    this._wrappedGetters = Object.create(null)
     const options = this._options
     if (newOptions.actions) {
       options.actions = newOptions.actions
@@ -271,7 +271,7 @@ function initModule (store, path, module, hot) {
   }
 
   if (getters) {
-    wrapGetters(store._getters, getters, path)
+    wrapGetters(store._wrappedGetters, getters, path)
   }
 
   if (modules) {

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ class Store {
     // strict mode
     this.strict = strict
 
-    // init internal vm with root state and getters
+    // init internal vm with root state
     // other options and sub modules will be
     // initialized in this.module method
     initStoreVM(this, state, {})

--- a/src/index.js
+++ b/src/index.js
@@ -271,9 +271,7 @@ function initModule (store, path, module, hot) {
   }
 
   if (getters) {
-    Object.keys(getters).forEach(key => {
-      wrapGetters(store._getters, getters, path)
-    })
+    wrapGetters(store._getters, getters, path)
   }
 
   if (modules) {
@@ -283,10 +281,10 @@ function initModule (store, path, module, hot) {
   }
 }
 
-function wrapGetters (getters, moduleGetters, modulePath, force) {
+function wrapGetters (getters, moduleGetters, modulePath) {
   Object.keys(moduleGetters).forEach(getterKey => {
     const rawGetter = moduleGetters[getterKey]
-    if (getters[getterKey] && !force) {
+    if (getters[getterKey]) {
       console.error(`[vuex] duplicate getter key: ${getterKey}`)
       return
     }

--- a/test/unit/test.js
+++ b/test/unit/test.js
@@ -208,12 +208,16 @@ describe('Vuex', () => {
     expect(() => {
       store.module('hi', {
         state: { a: 1 },
-        mutations: { inc: state => state.a++ }
+        mutations: { inc: state => state.a++ },
+        actions: { inc: ({ commit }) => commit('inc') },
+        getters: { a: state => state.a }
       })
     }).not.to.throw()
     expect(store.state.hi.a).to.equal(1)
-    store.commit('inc')
+    expect(store.getters.a).to.equal(1)
+    store.dispatch('inc')
     expect(store.state.hi.a).to.equal(2)
+    expect(store.getters.a).to.equal(2)
   })
 
   it('store injection', () => {


### PR DESCRIPTION
This patch fixes #248 

The initialization code of internal VM is moved into `initStoreVM` function (renamed from `initStoreState`).
And `initStoreVM` is called on the end of `module` method to register new getters to internal VM.