### PR TITLE
[2.0] Move silent flag out of payload

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,8 +30,8 @@ class Store {
     this.dispatch = function boundDispatch (type, payload) {
       return dispatch.call(store, type, payload)
     }
-    this.commit = function boundCommit (type, payload) {
-      return commit.call(store, type, payload)
+    this.commit = function boundCommit (type, payload, options) {
+      return commit.call(store, type, payload, options)
     }
 
     // strict mode
@@ -58,10 +58,11 @@ class Store {
     assert(false, `Use store.replaceState() to explicit replace store state.`)
   }
 
-  commit (type, payload) {
+  commit (type, payload, options) {
     // check object-style commit
     let mutation
     if (isObject(type) && type.type) {
+      options = payload
       payload = mutation = type
       type = type.type
     } else {
@@ -77,7 +78,7 @@ class Store {
         handler(payload)
       })
     })
-    if (!payload || !payload.silent) {
+    if (!options || !options.silent) {
       this._subscribers.forEach(sub => sub(mutation, this.state))
     }
   }

--- a/test/unit/test.js
+++ b/test/unit/test.js
@@ -623,10 +623,12 @@ describe('Vuex', () => {
       type: TEST,
       n: 2
     })
+    store.commit(TEST, { n: 3 }, { silent: true })
     store.commit({
       type: TEST,
-      silent: true,
-      n: 3
+      n: 4
+    }, {
+      silent: true
     })
     expect(mutations.length).toBe(2)
     expect(mutations[0].type).toBe(TEST)


### PR DESCRIPTION
Fix #277 

This patch moves silent flag of commit method to 3rd argument (2nd argument if object style commit).

```js
store.commit('increment', { amount: 1 }, { silent: true })

// Object style
store.commit({
  type: 'increment',
  amount: 1
}, { silent: true })
```