### PR TITLE
Avoid destroy watch callback even if resetting inner vm

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ class Store {
     this._wrappedGetters = Object.create(null)
     this._runtimeModules = Object.create(null)
     this._subscribers = []
+    this._watcherVM = new Vue()
 
     // bind commit and dispatch to self
     const store = this
@@ -108,7 +109,7 @@ class Store {
 
   watch (getter, cb, options) {
     assert(typeof getter === 'function', `store.watch only accepts a function.`)
-    return this._vm.$watch(() => getter(this.state), cb, options)
+    return this._watcherVM.$watch(() => getter(this.state), cb, options)
   }
 
   replaceState (state) {

--- a/test/unit/test.js
+++ b/test/unit/test.js
@@ -926,4 +926,31 @@ describe('Vuex', () => {
       done()
     })
   })
+
+  it('watch: with resetting vm', done => {
+    const store = new Vuex.Store({
+      state: {
+        count: 0
+      },
+      mutations: {
+        [TEST]: state => state.count++
+      }
+    })
+
+    const spy = jasmine.createSpy()
+    store.watch(state => state.count, spy)
+
+    // reset store vm
+    store.registerModule('test', {})
+
+    Vue.nextTick(() => {
+      store.commit(TEST)
+      expect(store.state.count).toBe(1)
+
+      Vue.nextTick(() => {
+        expect(spy).toHaveBeenCalled()
+        done()
+      })
+    })
+  })
 })


### PR DESCRIPTION
This patch fixes #279.

The watchers for store state are destroyed by `registerModule` because of the reset of the store VM.
This patch adds a new VM `_watcherVM`. It just watches store state and does not be destroyed by `registerModule`.