### PR TITLE
Fixed 'npm scripts' link in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ npm install
 $ npm run counter # run the counter example
 ```
 
-See [npm scripts](https://github.com/vuejs/vuex/blob/master/package.json#L11-L15) for all example npm scripts.
+See [npm scripts](https://github.com/vuejs/vuex/blob/master/package.json#L16-L20) for all example npm scripts.
 
 ## Principles
 


### PR DESCRIPTION
The 'npm scripts' link pointed at lines 11 to 15 of the package.json, but the example npm scripts are located at lines 16 to 20.