### PR TITLE
Support circular structure for logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "chat": "cd examples/chat && webpack-dev-server --inline --hot --config ../webpack.shared.config.js",
     "build": "node build/build.js",
     "build-examples": "BABEL_ENV=development webpack --config examples/webpack.build-all.config.js",
-    "unit": "BABEL_ENV=development mocha test/unit/test.js --compilers js:babel-core/register",
+    "unit": "BABEL_ENV=development mocha test/unit/*.js --compilers js:babel-core/register",
     "pree2e": "npm run build-examples",
     "e2e": "casperjs test --concise ./test/e2e",
     "test": "eslint src && npm run unit && npm run e2e",

--- a/src/plugins/logger.js
+++ b/src/plugins/logger.js
@@ -1,5 +1,7 @@
 // Credits: borrowed code from fcomb/redux-logger
 
+import { deepCopy } from '../util'
+
 export default function createLogger ({
   collapsed = true,
   transformer = state => state,
@@ -49,40 +51,4 @@ function repeat (str, times) {
 
 function pad (num, maxLength) {
   return repeat('0', maxLength - num.toString().length) + num
-}
-
-function find (list, f) {
-  return list.filter(f)[0]
-}
-
-/**
- * Deep copy the given object considering circular structure.
- * This function caches all nested objects and its copies.
- * If it detects circular structure, use cached copy to avoid infinite loop.
- */
-function deepCopy (obj, cache = []) {
-  // just return if obj is immutable value
-  if (obj === null || typeof obj !== 'object') {
-    return obj
-  }
-
-  // if obj is hit, it is in circular structure
-  const hit = find(cache, c => c.original === obj)
-  if (hit) {
-    return hit.copy
-  }
-
-  const copy = Array.isArray(obj) ? [] : {}
-  // put the copy into cache at first
-  // because we want to refer it in recursive deepCopy
-  cache.push({
-    original: obj,
-    copy
-  })
-
-  Object.keys(obj).forEach(key => {
-    copy[key] = deepCopy(obj[key], cache)
-  })
-
-  return copy
 }

--- a/src/util.js
+++ b/src/util.js
@@ -26,6 +26,54 @@ export function mergeObjects (arr) {
 }
 
 /**
+ * Get the first item that pass the test
+ * by second argument function
+ *
+ * @param {Array} list
+ * @param {Function} f
+ * @return {*}
+ */
+function find (list, f) {
+  return list.filter(f)[0]
+}
+
+/**
+ * Deep copy the given object considering circular structure.
+ * This function caches all nested objects and its copies.
+ * If it detects circular structure, use cached copy to avoid infinite loop.
+ *
+ * @param {*} obj
+ * @param {Array<Object>} cache
+ * @return {*}
+ */
+export function deepCopy (obj, cache = []) {
+  // just return if obj is immutable value
+  if (obj === null || typeof obj !== 'object') {
+    return obj
+  }
+
+  // if obj is hit, it is in circular structure
+  const hit = find(cache, c => c.original === obj)
+  if (hit) {
+    return hit.copy
+  }
+
+  const copy = Array.isArray(obj) ? [] : {}
+  // put the copy into cache at first
+  // because we want to refer it in recursive deepCopy
+  cache.push({
+    original: obj,
+    copy
+  })
+
+  Object.keys(obj).forEach(key => {
+    copy[key] = deepCopy(obj[key], cache)
+  })
+
+  return copy
+}
+
+/**
  * Check whether the given value is Object or not
  *
  * @param {*} obj

--- a/test/unit/util.js
+++ b/test/unit/util.js
@@ -1,0 +1,42 @@
+import { expect } from 'chai'
+import { deepCopy } from '../../src/util'
+
+describe('util', () => {
+  it('deepCopy: nornal structure', () => {
+    const original = {
+      a: 1,
+      b: 'string',
+      c: true,
+      d: null,
+      e: undefined
+    }
+    const copy = deepCopy(original)
+
+    expect(copy).to.deep.equal(original)
+  })
+
+  it('deepCopy: nested structure', () => {
+    const original = {
+      a: {
+        b: 1,
+        c: [2, 3, {
+          d: 4
+        }]
+      }
+    }
+    const copy = deepCopy(original)
+
+    expect(copy).to.deep.equal(original)
+  })
+
+  it('deepCopy: circular structure', () => {
+    const original = {
+      a: 1
+    }
+    original.circular = original
+
+    const copy = deepCopy(original)
+
+    expect(copy).to.deep.equal(original)
+  })
+})


### PR DESCRIPTION
Fix #326 

The logger plugin throws error if state has circular structure because `JSON.stringify()` cannot handle it.
I added `deepCopy` that handle circular structure and use it in the logger plugin.

I will also open a PR to `next` if this patch is ok.