### PR TITLE
Fix: arguments for getters missing in API

### DIFF
--- a/docs/en/api.md
+++ b/docs/en/api.md
@@ -48,8 +48,13 @@ const store = new Vuex.Store({ ...options })
 
   - type: `{ [key: string]: Function }`
 
-    Register getters on the store. The getter function receives the `state` as the first argument (will be module local state if defined in a module).
-
+    Register getters on the store. The getter function receives following arguments:
+    
+    ```
+    state,     // will be module local state if defined in a module).
+    getters,   // same as store.getters
+    rootState  // same as store.state
+    ```
     Registered getters are exposed on `store.getters`.
 
     [Details](getters.md)

--- a/docs/en/api.md
+++ b/docs/en/api.md
@@ -48,7 +48,7 @@ const store = new Vuex.Store({ ...options })
 
   - type: `{ [key: string]: Function }`
 
-    Register getters on the store. The getter function receives following arguments:
+    Register getters on the store. The getter function receives the following arguments:
     
     ```
     state,     // will be module local state if defined in a module).

--- a/docs/en/api.md
+++ b/docs/en/api.md
@@ -51,7 +51,7 @@ const store = new Vuex.Store({ ...options })
     Register getters on the store. The getter function receives the following arguments:
     
     ```
-    state,     // will be module local state if defined in a module).
+    state,     // will be module local state if defined in a module.
     getters,   // same as store.getters
     rootState  // same as store.state
     ```


### PR DESCRIPTION
as per `v2.0.0-rc.3`, getters receive 3 arguments: `state, getters, rootState`. However only the first is currently documented. This PR fixes this.