### PR TITLE
Docs: Match context explanation with code example

### DIFF
--- a/docs/en/actions.md
+++ b/docs/en/actions.md
@@ -25,7 +25,7 @@ const store = new Vuex.Store({
 })
 ```
 
-Action handlers receive a context object which exposes the same set of methods/properties on the store instance, so you can call `ctx.commit` to commit a mutation, or access the state and getters via `ctx.state` and `ctx.getters`. We will see why this context object is not the store instance itself when we introduce [Modules](modules.md) later.
+Action handlers receive a context object which exposes the same set of methods/properties on the store instance, so you can call `context.commit` to commit a mutation, or access the state and getters via `context.state` and `context.getters`. We will see why this context object is not the store instance itself when we introduce [Modules](modules.md) later.
 
 In practice, we often use ES2015 [argument destructuring](https://github.com/lukehoban/es6features#destructuring) to simplify the code a bit (especially when we need to call `commit` multiple times):
 


### PR DESCRIPTION
Little nitpick, the variable in the description doesn't match the variable in the example. Alternatively, everything could be renamed to `ctx`.