### PR TITLE
[docs] Add helpers reference and update mapState description

### DIFF
--- a/docs/en/api.md
+++ b/docs/en/api.md
@@ -157,3 +157,21 @@ const store = new Vuex.Store({ ...options })
 - **`hotUpdate(newOptions: Object)`**
 
   Hot swap new actions and mutations. [Details](hot-reload.md)
+
+### Component Binding Helpers
+
+- **`mapState(map: Array<string> | Object): Object`**
+
+  Create component computed options that return the sub tree of the Vuex store. [Defails](state.md#the-mapstate-helper)
+
+- **`mapGetters(map: Array<string> | Object): Object`**
+
+  Create component computed options that return the evaluated value of a getter. [Details](getters.md#the-mapgetters-helper)
+
+- **`mapActions(map: Array<string> | Object): Object`**
+
+  Create component methods options that dispatch an action. [Details](actions.md#dispatching-actions-in-components)
+
+- **`mapMutations(map: Array<string> | Object): Object`**
+
+  Create component methods options that commit a mutation. [Details](mutations.md#commiting-mutations-in-components)

--- a/docs/en/state.md
+++ b/docs/en/state.md
@@ -70,12 +70,24 @@ export default {
     // arrow functions can make the code very succinct!
     count: state => state.count,
 
+    // passing the string value 'count' is same as `state => state.count`
+    countAlias: 'count',
+
     // to access local state with `this`, a normal function must be used
     countPlusLocalState (state) {
       return state.count + this.localCount
     }
   })
 }
+```
+
+We can also pass a string array to `mapState` when the name of mapped computed property is same as state sub tree name.
+
+``` js
+computed: mapState([
+  // map this.count to store.state.count
+  'count'
+])
 ```
 
 ### Object Spread Operator


### PR DESCRIPTION
I've added `mapState`, `mapGetters`, `mapActions` and `mapMutations` to API reference.
And also update `mapState` description in state.md.