### PR TITLE
Fixed a missing semi-colon in the code example

### DIFF
--- a/docs/en/getters.md
+++ b/docs/en/getters.md
@@ -73,7 +73,7 @@ export default {
   // ...
   computed: {
     // mix the getters into computed with object spread operator
-    ...mapGetters([
+    ...mapGetters: ([
       'doneTodosCount',
       'anotherGetter',
       // ...
@@ -85,7 +85,7 @@ export default {
 If you want to map a getter to a different name, use an object:
 
 ``` js
-mapGetters({
+mapGetters: ({
   // map this.doneCount to store.getters.doneTodosCount
   doneCount: 'doneTodosCount'
 })


### PR DESCRIPTION
The code example provided didn't contain a semi-colon where required.