### PR TITLE
[example] Move module specific getters and actions into each module

### DIFF
--- a/examples/shopping-cart/store/actions.js
+++ b/examples/shopping-cart/store/actions.js
@@ -1,4 +1,3 @@
-import shop from '../api/shop'
 import * as types from './mutation-types'
 
 export const addToCart = ({ commit }, product) => {
@@ -7,20 +6,4 @@ export const addToCart = ({ commit }, product) => {
       id: product.id
     })
   }
-}
-
-export const checkout = ({ commit, state }, products) => {
-  const savedCartItems = [...state.cart.added]
-  commit(types.CHECKOUT_REQUEST)
-  shop.buyProducts(
-    products,
-    () => commit(types.CHECKOUT_SUCCESS),
-    () => commit(types.CHECKOUT_FAILURE, { savedCartItems })
-  )
-}
-
-export const getAllProducts = ({ commit }) => {
-  shop.getProducts(products => {
-    commit(types.RECEIVE_PRODUCTS, { products })
-  })
 }

--- a/examples/shopping-cart/store/getters.js
+++ b/examples/shopping-cart/store/getters.js
@@ -1,7 +1,3 @@
-export const checkoutStatus = state => state.cart.checkoutStatus
-
-export const allProducts = state => state.products.all
-
 export const cartProducts = state => {
   return state.cart.added.map(({ id, quantity }) => {
     const product = state.products.all.find(p => p.id === id)

--- a/examples/shopping-cart/store/modules/cart.js
+++ b/examples/shopping-cart/store/modules/cart.js
@@ -1,3 +1,4 @@
+import shop from '../../api/shop'
 import * as types from '../mutation-types'
 
 // initial state
@@ -5,6 +6,24 @@ import * as types from '../mutation-types'
 const state = {
   added: [],
   checkoutStatus: null
+}
+
+// getters
+const getters = {
+  checkoutStatus: state => state.checkoutStatus
+}
+
+// actions
+const actions = {
+  checkout ({ commit, state }, products) {
+    const savedCartItems = [...state.added]
+    commit(types.CHECKOUT_REQUEST)
+    shop.buyProducts(
+      products,
+      () => commit(types.CHECKOUT_SUCCESS),
+      () => commit(types.CHECKOUT_FAILURE, { savedCartItems })
+    )
+  }
 }
 
 // mutations
@@ -41,5 +60,7 @@ const mutations = {
 
 export default {
   state,
+  getters,
+  actions,
   mutations
 }

--- a/examples/shopping-cart/store/modules/products.js
+++ b/examples/shopping-cart/store/modules/products.js
@@ -1,8 +1,23 @@
+import shop from '../../api/shop'
 import * as types from '../mutation-types'
 
 // initial state
 const state = {
   all: []
+}
+
+// getters
+const getters = {
+  allProducts: state => state.all
+}
+
+// actions
+const actions = {
+  getAllProducts ({ commit }) {
+    shop.getProducts(products => {
+      commit(types.RECEIVE_PRODUCTS, { products })
+    })
+  }
 }
 
 // mutations
@@ -18,5 +33,7 @@ const mutations = {
 
 export default {
   state,
+  getters,
+  actions,
   mutations
 }


### PR DESCRIPTION
As being pointed out on #370, actions and getters in shopping cart example does not belong to each module. It could mislead the v2.0's module approach.

I've move module specific getters and actions into each module, but keep the ones depend on both module on root.
