### PR TITLE
Implement module `namespace` option

### DIFF
--- a/docs/en/modules.md
+++ b/docs/en/modules.md
@@ -156,6 +156,22 @@ export default {
 }
 ```
 
+#### Caveat for Plugin Developers
+
+You may care about unpredictable namespacing for your modules when you create a [plugin](plugins.md) that provides the modules and let users add them to a Vuex store. Your modules will be also namespaced if the plugin users add your modules under a namespaced module. To adapt this situation, you may need to receive a namespace value via your plugin option:
+
+``` js
+// get namespace value via plugin option
+// and returns Vuex plugin function
+export function createPlugin (options = {}) {
+  return function (store) {
+    // add namespace to plugin module's types
+    const namespace = options.namespace || ''
+    store.dispatch(namespace + 'pluginAction')
+  }
+}
+```
+
 ### Dynamic Module Registration
 
 You can register a module **after** the store has been created with the `store.registerModule` method:

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,6 @@ class Store {
     } = options
 
     // store internal state
-    this._options = options
     this._committing = false
     this._actions = Object.create(null)
     this._mutations = Object.create(null)

--- a/src/index.js
+++ b/src/index.js
@@ -266,6 +266,10 @@ function localize (store, namespacer, hasNamespace) {
 
       if (!options || !options.root) {
         type = namespacer(type, 'action')
+        if (!store._actionss[type]) {
+          console.error(`[vuex] unknown local action type: ${args.type}, global type: ${type}`)
+          return
+        }
       }
 
       return store.dispatch(type, payload)
@@ -278,6 +282,10 @@ function localize (store, namespacer, hasNamespace) {
 
       if (!options || !options.root) {
         type = namespacer(type, 'mutation')
+        if (!store._mutations[type]) {
+          console.error(`[vuex] unknown local mutation type: ${args.type}, global type: ${type}`)
+          return
+        }
       }
 
       store.commit(type, payload, options)

--- a/src/index.js
+++ b/src/index.js
@@ -211,6 +211,7 @@ function resetStoreVM (store, state) {
 
 function installModule (store, rootState, path, module, hot) {
   const isRoot = !path.length
+  const namespacer = store._modules.getNamespacer(path)
 
   // set state
   if (!isRoot && !hot) {
@@ -222,15 +223,15 @@ function installModule (store, rootState, path, module, hot) {
   }
 
   module.forEachMutation((mutation, key) => {
-    registerMutation(store, key, mutation, path)
+    registerMutation(store, namespacer(key, 'mutation'), mutation, path)
   })
 
   module.forEachAction((action, key) => {
-    registerAction(store, key, action, path)
+    registerAction(store, namespacer(key, 'action'), action, path)
   })
 
   module.forEachGetter((getter, key) => {
-    registerGetter(store, key, getter, path)
+    registerGetter(store, namespacer(key, 'getter'), getter, path)
   })
 
   module.forEachChild((child, key) => {

--- a/src/index.js
+++ b/src/index.js
@@ -221,7 +221,7 @@ function installModule (store, rootState, path, module, hot) {
     const parentState = getNestedState(rootState, path.slice(0, -1))
     const moduleName = path[path.length - 1]
     store._withCommit(() => {
-      Vue.set(parentState, moduleName, module.state || {})
+      Vue.set(parentState, moduleName, module.state)
     })
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -292,7 +292,7 @@ function localize (store, namespace) {
 }
 
 function localizeGetters (store, namespace) {
-  const gettersProxy = Object.create(null)
+  const gettersProxy = {}
 
   const splitPos = namespace.length
   Object.keys(store.getters).forEach(type => {

--- a/src/module/module-collection.js
+++ b/src/module/module-collection.js
@@ -20,6 +20,17 @@ export default class ModuleCollection {
     }, this.root)
   }
 
+  getNamespacer (path) {
+    let module = this.root
+    return path.reduce((namespacer, key) => {
+      module = module.getChild(key)
+      const moduleNamespacer = module.namespacer
+      return (type, category) => {
+        return namespacer(moduleNamespacer(type, category), category)
+      }
+    }, identity)
+  }
+
   update (rawRootModule) {
     update(this.root, rawRootModule)
   }

--- a/src/module/module-collection.js
+++ b/src/module/module-collection.js
@@ -1,0 +1,66 @@
+import Module from './module'
+import { forEachValue, identity } from '../util'
+
+export default class ModuleCollection {
+  constructor (rawRootModule) {
+    // register root module (Vuex.Store options)
+    this.root = new Module(rawRootModule, false)
+
+    // register all nested modules
+    if (rawRootModule.modules) {
+      forEachValue(rawRootModule.modules, (rawModule, key) => {
+        this.register([key], rawModule, false)
+      })
+    }
+  }
+
+  get (path) {
+    return path.reduce((module, key) => {
+      return module.getChild(key)
+    }, this.root)
+  }
+
+  update (rawRootModule) {
+    update(this.root, rawRootModule)
+  }
+
+  register (path, rawModule, runtime = true) {
+    const parent = this.get(path.slice(0, -1))
+    const newModule = new Module(rawModule, runtime)
+    parent.addChild(path[path.length - 1], newModule)
+
+    // register nested modules
+    if (rawModule.modules) {
+      forEachValue(rawModule.modules, (rawChildModule, key) => {
+        this.register(path.concat(key), rawChildModule, runtime)
+      })
+    }
+  }
+
+  unregister (path) {
+    const parent = this.get(path.slice(0, -1))
+    const key = path[path.length - 1]
+    if (!parent.getChild(key).runtime) return
+
+    parent.removeChild(key)
+  }
+}
+
+function update (targetModule, newModule) {
+  // update target module
+  targetModule.update(newModule)
+
+  // update nested modules
+  if (newModule.modules) {
+    for (const key in newModule.modules) {
+      if (!targetModule.getChild(key)) {
+        console.warn(
+          `[vuex] trying to add a new module '${key}' on hot reloading, ` +
+          'manual reload is needed'
+        )
+        return
+      }
+      update(targetModule.getChild(key), newModule.modules[key])
+    }
+  }
+}

--- a/src/module/module-collection.js
+++ b/src/module/module-collection.js
@@ -1,5 +1,5 @@
 import Module from './module'
-import { forEachValue, identity } from '../util'
+import { forEachValue } from '../util'
 
 export default class ModuleCollection {
   constructor (rawRootModule) {
@@ -20,23 +20,12 @@ export default class ModuleCollection {
     }, this.root)
   }
 
-  hasNamespace (path) {
+  getNamespace (path) {
     let module = this.root
-    return path.reduce((result, key) => {
+    return path.reduce((namespace, key) => {
       module = module.getChild(key)
-      return result || module.hasNamespace
-    }, false)
-  }
-
-  getNamespacer (path) {
-    let module = this.root
-    return path.reduce((namespacer, key) => {
-      module = module.getChild(key)
-      const moduleNamespacer = module.namespacer
-      return (type, category) => {
-        return namespacer(moduleNamespacer(type, category), category)
-      }
-    }, identity)
+      return namespace + module.namespace
+    }, '')
   }
 
   update (rawRootModule) {

--- a/src/module/module-collection.js
+++ b/src/module/module-collection.js
@@ -20,6 +20,14 @@ export default class ModuleCollection {
     }, this.root)
   }
 
+  hasNamespace (path) {
+    let module = this.root
+    return path.reduce((result, key) => {
+      module = module.getChild(key)
+      return result || module.hasNamespace
+    }, false)
+  }
+
   getNamespacer (path) {
     let module = this.root
     return path.reduce((namespacer, key) => {

--- a/src/module/module.js
+++ b/src/module/module.js
@@ -11,6 +11,16 @@ export default class Module {
     return this._rawModule.state
   }
 
+  get namespacer () {
+    // if the namespace option is string value, convert it to a function
+    let namespacer = this._rawModule.namespace || ''
+    if (typeof namespacer === 'string') {
+      const prefix = namespacer
+      namespacer = (type, category) => prefix + type
+    }
+    return namespacer
+  }
+
   addChild (key, module) {
     this._children[key] = module
   }

--- a/src/module/module.js
+++ b/src/module/module.js
@@ -34,6 +34,7 @@ export default class Module {
   }
 
   update (rawModule) {
+    this._rawModule.namespace = rawModule.namespace
     if (rawModule.actions) {
       this._rawModule.actions = rawModule.actions
     }

--- a/src/module/module.js
+++ b/src/module/module.js
@@ -11,18 +11,8 @@ export default class Module {
     return this._rawModule.state
   }
 
-  get hasNamespace () {
-    return this._rawModule.namespace != null && this._rawModule.namespace !== ''
-  }
-
-  get namespacer () {
-    // if the namespace option is string value, convert it to a function
-    let namespacer = this._rawModule.namespace || ''
-    if (typeof namespacer === 'string') {
-      const prefix = namespacer
-      namespacer = (type, category) => prefix + type
-    }
-    return namespacer
+  get namespace () {
+    return this._rawModule.namespace || ''
   }
 
   addChild (key, module) {

--- a/src/module/module.js
+++ b/src/module/module.js
@@ -11,6 +11,10 @@ export default class Module {
     return this._rawModule.state
   }
 
+  get hasNamespace () {
+    return this._rawModule.namespace != null && this._rawModule.namespace !== ''
+  }
+
   get namespacer () {
     // if the namespace option is string value, convert it to a function
     let namespacer = this._rawModule.namespace || ''

--- a/src/module/module.js
+++ b/src/module/module.js
@@ -8,7 +8,7 @@ export default class Module {
   }
 
   get state () {
-    return this._rawModule.state
+    return this._rawModule.state || {}
   }
 
   get namespace () {

--- a/src/module/module.js
+++ b/src/module/module.js
@@ -1,0 +1,59 @@
+import { forEachValue } from '../util'
+
+export default class Module {
+  constructor (rawModule, runtime) {
+    this.runtime = runtime
+    this._children = Object.create(null)
+    this._rawModule = rawModule
+  }
+
+  get state () {
+    return this._rawModule.state
+  }
+
+  addChild (key, module) {
+    this._children[key] = module
+  }
+
+  removeChild (key) {
+    delete this._children[key]
+  }
+
+  getChild (key) {
+    return this._children[key]
+  }
+
+  update (rawModule) {
+    if (rawModule.actions) {
+      this._rawModule.actions = rawModule.actions
+    }
+    if (rawModule.mutations) {
+      this._rawModule.mutations = rawModule.mutations
+    }
+    if (rawModule.getters) {
+      this._rawModule.getters = rawModule.getters
+    }
+  }
+
+  forEachChild (fn) {
+    forEachValue(this._children, fn)
+  }
+
+  forEachGetter (fn) {
+    if (this._rawModule.getters) {
+      forEachValue(this._rawModule.getters, fn)
+    }
+  }
+
+  forEachAction (fn) {
+    if (this._rawModule.actions) {
+      forEachValue(this._rawModule.actions, fn)
+    }
+  }
+
+  forEachMutation (fn) {
+    if (this._rawModule.mutations) {
+      forEachValue(this._rawModule.mutations, fn)
+    }
+  }
+}

--- a/src/util.js
+++ b/src/util.js
@@ -46,6 +46,13 @@ export function deepCopy (obj, cache = []) {
   return copy
 }
 
+/**
+ * forEach for object
+ */
+export function forEachValue (obj, fn) {
+  Object.keys(obj).forEach(key => fn(obj[key], key))
+}
+
 export function isObject (obj) {
   return obj !== null && typeof obj === 'object'
 }

--- a/src/util.js
+++ b/src/util.js
@@ -53,14 +53,6 @@ export function forEachValue (obj, fn) {
   Object.keys(obj).forEach(key => fn(obj[key], key))
 }
 
-/**
- * Returns given argument itself
- * Used for initial value to fold functions
- */
-export function identity (value) {
-  return value
-}
-
 export function isObject (obj) {
   return obj !== null && typeof obj === 'object'
 }

--- a/src/util.js
+++ b/src/util.js
@@ -53,6 +53,14 @@ export function forEachValue (obj, fn) {
   Object.keys(obj).forEach(key => fn(obj[key], key))
 }
 
+/**
+ * Returns given argument itself
+ * Used for initial value to fold functions
+ */
+export function identity (value) {
+  return value
+}
+
 export function isObject (obj) {
   return obj !== null && typeof obj === 'object'
 }

--- a/test/unit/jasmine.json
+++ b/test/unit/jasmine.json
@@ -3,6 +3,7 @@
   "spec_files": [
     "test.js",
     "util.js",
+    "module/module.js",
     "module/module-collection.js"
   ],
   "helpers": [

--- a/test/unit/jasmine.json
+++ b/test/unit/jasmine.json
@@ -2,7 +2,8 @@
   "spec_dir": "test/unit",
   "spec_files": [
     "test.js",
-    "util.js"
+    "util.js",
+    "module/module-collection.js"
   ],
   "helpers": [
     "../../node_modules/babel-register/lib/node.js"

--- a/test/unit/module/module-collection.js
+++ b/test/unit/module/module-collection.js
@@ -1,0 +1,66 @@
+import ModuleCollection from '../../../src/module/module-collection'
+
+describe('ModuleCollection', () => {
+  it('get', () => {
+    const collection = new ModuleCollection({
+      state: { value: 1 },
+      modules: {
+        a: {
+          state: { value: 2 }
+        },
+        b: {
+          state: { value: 3 },
+          modules: {
+            c: {
+              state: { value: 4 }
+            }
+          }
+        }
+      }
+    })
+    expect(collection.get([]).state.value).toBe(1)
+    expect(collection.get(['a']).state.value).toBe(2)
+    expect(collection.get(['b']).state.value).toBe(3)
+    expect(collection.get(['b', 'c']).state.value).toBe(4)
+  })
+
+  it('register', () => {
+    const collection = new ModuleCollection({})
+    collection.register(['a'], {
+      state: { value: 1 }
+    })
+    collection.register(['b'], {
+      state: { value: 2 }
+    })
+    collection.register(['a', 'b'], {
+      state: { value: 3 }
+    })
+
+    expect(collection.get(['a']).state.value).toBe(1)
+    expect(collection.get(['b']).state.value).toBe(2)
+    expect(collection.get(['a', 'b']).state.value).toBe(3)
+  })
+
+  it('unregister', () => {
+    const collection = new ModuleCollection({})
+    collection.register(['a'], {
+      state: { value: true }
+    })
+    expect(collection.get(['a']).state.value).toBe(true)
+
+    collection.unregister(['a'])
+    expect(collection.get(['a'])).toBe(undefined)
+  })
+
+  it('does not unregister initial modules', () => {
+    const collection = new ModuleCollection({
+      modules: {
+        a: {
+          state: { value: true }
+        }
+      }
+    })
+    collection.unregister(['a'])
+    expect(collection.get(['a']).state.value).toBe(true)
+  })
+})

--- a/test/unit/module/module-collection.js
+++ b/test/unit/module/module-collection.js
@@ -24,41 +24,7 @@ describe('ModuleCollection', () => {
     expect(collection.get(['b', 'c']).state.value).toBe(4)
   })
 
-  it('hasNamespace', () => {
-    const collection = new ModuleCollection({
-      namespace: 'ignore/',
-      modules: {
-        a: {
-          namespace: 'a/',
-          modules: {
-            b: {
-              modules: {
-                c: {
-                  namespace: 'c/'
-                }
-              }
-            }
-          }
-        },
-        d: {
-          modules: {
-            e: {
-              namespace: 'e/'
-            }
-          }
-        }
-      }
-    })
-
-    expect(collection.hasNamespace([])).toBe(false)
-    expect(collection.hasNamespace(['a'])).toBe(true)
-    expect(collection.hasNamespace(['a', 'b'])).toBe(true)
-    expect(collection.hasNamespace(['a', 'b', 'c'])).toBe(true)
-    expect(collection.hasNamespace(['d'])).toBe(false)
-    expect(collection.hasNamespace(['d', 'e'])).toBe(true)
-  })
-
-  it('getNamespacer', () => {
+  it('getNamespace', () => {
     const module = (namespace, children) => {
       return {
         namespace,
@@ -72,27 +38,19 @@ describe('ModuleCollection', () => {
           b: module(null, {
             c: module('c/')
           }),
-          d: module('d/'),
-          e: module((type, category) => {
-            return category + '-e/' + type
-          }, {
-            f: module('f/')
-          })
+          d: module('d/')
         })
       }
     })
     const check = (path, expected) => {
       const type = 'test'
-      const category = 'getter'
-      const namespacer = collection.getNamespacer(path)
-      expect(namespacer(type, category)).toBe(expected)
+      const namespace = collection.getNamespace(path)
+      expect(namespace + type).toBe(expected)
     }
     check(['a'], 'a/test')
     check(['a', 'b'], 'a/test')
     check(['a', 'b', 'c'], 'a/c/test')
     check(['a', 'd'], 'a/d/test')
-    check(['a', 'e'], `a/getter-e/test`)
-    check(['a', 'e', 'f'], `a/getter-e/f/test`)
   })
 
   it('register', () => {

--- a/test/unit/module/module-collection.js
+++ b/test/unit/module/module-collection.js
@@ -24,6 +24,43 @@ describe('ModuleCollection', () => {
     expect(collection.get(['b', 'c']).state.value).toBe(4)
   })
 
+  it('getNamespacer', () => {
+    const module = (namespace, children) => {
+      return {
+        namespace,
+        modules: children
+      }
+    }
+    const collection = new ModuleCollection({
+      namespace: 'ignore/', // root module namespace should be ignored
+      modules: {
+        a: module('a/', {
+          b: module(null, {
+            c: module('c/')
+          }),
+          d: module('d/'),
+          e: module((type, category) => {
+            return category + '-e/' + type
+          }, {
+            f: module('f/')
+          })
+        })
+      }
+    })
+    const check = (path, expected) => {
+      const type = 'test'
+      const category = 'getter'
+      const namespacer = collection.getNamespacer(path)
+      expect(namespacer(type, category)).toBe(expected)
+    }
+    check(['a'], 'a/test')
+    check(['a', 'b'], 'a/test')
+    check(['a', 'b', 'c'], 'a/c/test')
+    check(['a', 'd'], 'a/d/test')
+    check(['a', 'e'], `a/getter-e/test`)
+    check(['a', 'e', 'f'], `a/getter-e/f/test`)
+  })
+
   it('register', () => {
     const collection = new ModuleCollection({})
     collection.register(['a'], {

--- a/test/unit/module/module-collection.js
+++ b/test/unit/module/module-collection.js
@@ -24,6 +24,40 @@ describe('ModuleCollection', () => {
     expect(collection.get(['b', 'c']).state.value).toBe(4)
   })
 
+  it('hasNamespace', () => {
+    const collection = new ModuleCollection({
+      namespace: 'ignore/',
+      modules: {
+        a: {
+          namespace: 'a/',
+          modules: {
+            b: {
+              modules: {
+                c: {
+                  namespace: 'c/'
+                }
+              }
+            }
+          }
+        },
+        d: {
+          modules: {
+            e: {
+              namespace: 'e/'
+            }
+          }
+        }
+      }
+    })
+
+    expect(collection.hasNamespace([])).toBe(false)
+    expect(collection.hasNamespace(['a'])).toBe(true)
+    expect(collection.hasNamespace(['a', 'b'])).toBe(true)
+    expect(collection.hasNamespace(['a', 'b', 'c'])).toBe(true)
+    expect(collection.hasNamespace(['d'])).toBe(false)
+    expect(collection.hasNamespace(['d', 'e'])).toBe(true)
+  })
+
   it('getNamespacer', () => {
     const module = (namespace, children) => {
       return {

--- a/test/unit/module/module.js
+++ b/test/unit/module/module.js
@@ -1,0 +1,24 @@
+import Module from '../../../src/module/module'
+
+describe('Module', () => {
+  it('get namespacer: no namespace option', () => {
+    const module = new Module({})
+    expect(module.namespacer('test', 'getter')).toBe('test')
+  })
+
+  it('get namespacer: namespace option is string value', () => {
+    const module = new Module({
+      namespace: 'prefix/'
+    })
+    expect(module.namespacer('test', 'getter')).toBe('prefix/test')
+  })
+
+  it('get namespacer: namespace option is function value', () => {
+    const module = new Module({
+      namespace (type, category) {
+        return category + '/' + type
+      }
+    })
+    expect(module.namespacer('test', 'getter')).toBe('getter/test')
+  })
+})

--- a/test/unit/module/module.js
+++ b/test/unit/module/module.js
@@ -1,38 +1,15 @@
 import Module from '../../../src/module/module'
 
 describe('Module', () => {
-  it('get hasNamespace', () => {
-    let module = new Module({})
-    expect(module.hasNamespace).toBe(false)
-
-    module = new Module({ namespace: '' })
-    expect(module.hasNamespace).toBe(false)
-
-    module = new Module({ namespace: 'prefix/' })
-    expect(module.hasNamespace).toBe(true)
-
-    module = new Module({ namespace: () => {} })
-    expect(module.hasNamespace).toBe(true)
-  })
-
   it('get namespacer: no namespace option', () => {
     const module = new Module({})
-    expect(module.namespacer('test', 'getter')).toBe('test')
+    expect(module.namespace).toBe('')
   })
 
   it('get namespacer: namespace option is string value', () => {
     const module = new Module({
       namespace: 'prefix/'
     })
-    expect(module.namespacer('test', 'getter')).toBe('prefix/test')
-  })
-
-  it('get namespacer: namespace option is function value', () => {
-    const module = new Module({
-      namespace (type, category) {
-        return category + '/' + type
-      }
-    })
-    expect(module.namespacer('test', 'getter')).toBe('getter/test')
+    expect(module.namespace).toBe('prefix/')
   })
 })

--- a/test/unit/module/module.js
+++ b/test/unit/module/module.js
@@ -1,6 +1,20 @@
 import Module from '../../../src/module/module'
 
 describe('Module', () => {
+  it('get state', () => {
+    const module = new Module({
+      state: {
+        value: true
+      }
+    })
+    expect(module.state).toEqual({ value: true })
+  })
+
+  it('get state: should return object if state option is empty', () => {
+    const module = new Module({})
+    expect(module.state).toEqual({})
+  })
+
   it('get namespacer: no namespace option', () => {
     const module = new Module({})
     expect(module.namespace).toBe('')

--- a/test/unit/module/module.js
+++ b/test/unit/module/module.js
@@ -1,6 +1,20 @@
 import Module from '../../../src/module/module'
 
 describe('Module', () => {
+  it('get hasNamespace', () => {
+    let module = new Module({})
+    expect(module.hasNamespace).toBe(false)
+
+    module = new Module({ namespace: '' })
+    expect(module.hasNamespace).toBe(false)
+
+    module = new Module({ namespace: 'prefix/' })
+    expect(module.hasNamespace).toBe(true)
+
+    module = new Module({ namespace: () => {} })
+    expect(module.hasNamespace).toBe(true)
+  })
+
   it('get namespacer: no namespace option', () => {
     const module = new Module({})
     expect(module.namespacer('test', 'getter')).toBe('test')

--- a/test/unit/test.js
+++ b/test/unit/test.js
@@ -640,47 +640,6 @@ describe('Vuex', () => {
     expect(mutationSpy).toHaveBeenCalled()
   })
 
-  it('module: use other module that has same namespace', done => {
-    const actionSpy = jasmine.createSpy()
-    const mutationSpy = jasmine.createSpy()
-
-    const store = new Vuex.Store({
-      modules: {
-        parent: {
-          namespace: 'prefix/',
-
-          modules: {
-            a: {
-              state: { value: 'a' },
-              getters: { foo: state => state.value },
-              actions: { foo: actionSpy },
-              mutations: { foo: mutationSpy }
-            },
-
-            b: {
-              state: { value: 'b' },
-              actions: {
-                test ({ dispatch, commit, getters }) {
-                  expect(getters.foo).toBe('a')
-
-                  dispatch('foo')
-                  expect(actionSpy).toHaveBeenCalled()
-
-                  commit('foo')
-                  expect(mutationSpy).toHaveBeenCalled()
-
-                  done()
-                }
-              }
-            }
-          }
-        }
-      }
-    })
-
-    store.dispatch('prefix/test')
-  })
-
   it('module: nested namespace', () => {
     // mock module generator
     const actionSpys = []
@@ -808,6 +767,49 @@ describe('Vuex', () => {
             }
           },
           mutations: { foo: moduleMutationSpy }
+        }
+      }
+    })
+
+    store.dispatch('prefix/test')
+  })
+
+  it('module: use other module that has same namespace', done => {
+    const actionSpy = jasmine.createSpy()
+    const mutationSpy = jasmine.createSpy()
+
+    const store = new Vuex.Store({
+      modules: {
+        parent: {
+          namespace: 'prefix/',
+
+          modules: {
+            a: {
+              state: { value: 'a' },
+              getters: { foo: state => state.value },
+              actions: { foo: actionSpy },
+              mutations: { foo: mutationSpy }
+            },
+
+            b: {
+              state: { value: 'b' },
+              getters: { bar: (state, getters) => getters.foo },
+              actions: {
+                test ({ dispatch, commit, getters }) {
+                  expect(getters.foo).toBe('a')
+                  expect(getters.bar).toBe('a')
+
+                  dispatch('foo')
+                  expect(actionSpy).toHaveBeenCalled()
+
+                  commit('foo')
+                  expect(mutationSpy).toHaveBeenCalled()
+
+                  done()
+                }
+              }
+            }
+          }
         }
       }
     })

--- a/test/unit/test.js
+++ b/test/unit/test.js
@@ -608,7 +608,7 @@ describe('Vuex', () => {
     })
   })
 
-  it('module: namespace string', () => {
+  it('module: namespace', () => {
     const actionSpy = jasmine.createSpy()
     const mutationSpy = jasmine.createSpy()
 
@@ -640,47 +640,7 @@ describe('Vuex', () => {
     expect(mutationSpy).toHaveBeenCalled()
   })
 
-  it('module: namespace generator function', () => {
-    const namespace = (type, category) => {
-      return category + '/' + type
-    }
-
-    const actionSpy = jasmine.createSpy()
-    const mutationSpy = jasmine.createSpy()
-
-    const store = new Vuex.Store({
-      modules: {
-        a: {
-          namespace,
-          state: {
-            a: 1
-          },
-          getters: {
-            b: () => 2
-          },
-          actions: {
-            [TEST]: actionSpy
-          },
-          mutations: {
-            [TEST]: mutationSpy
-          }
-        }
-      }
-    })
-
-    expect(store.state.a.a).toBe(1)
-    expect(store.getters['getter/b']).toBe(2)
-    store.dispatch('action/' + TEST)
-    expect(actionSpy).toHaveBeenCalled()
-    store.commit('mutation/' + TEST)
-    expect(mutationSpy).toHaveBeenCalled()
-  })
-
   it('module: nested namespace', () => {
-    const prefixCategory = namespace => (type, category) => {
-      return category + '-' + namespace + type
-    }
-
     // mock module generator
     const actionSpys = []
     const mutationSpys = []
@@ -716,26 +676,22 @@ describe('Vuex', () => {
           c: createModule('c', 'c/') // a/c/c
         }),
         d: createModule('d', 'd/'), // a/d/d
-        e: createModule('e', prefixCategory('e/'), { // a/(category)-e/e
-          f: createModule('f', prefixCategory('f/')) // a/(category)-e/(category)-f/f
-        })
       })
     }
 
     const store = new Vuex.Store({ modules })
 
-    const expectedTypes = category => [
-      'a/a', 'a/b', 'a/c/c', 'a/d/d',
-      `a/${category}-e/e`, `a/${category}-e/${category}-f/f`
+    const expectedTypes = [
+      'a/a', 'a/b', 'a/c/c', 'a/d/d'
     ]
 
     // getters
-    expectedTypes('getter').forEach(type => {
+    expectedTypes.forEach(type => {
       expect(store.getters[type]).toBe(true)
     })
 
     // actions
-    expectedTypes('action').forEach(type => {
+    expectedTypes.forEach(type => {
       store.dispatch(type)
     })
     actionSpys.forEach(spy => {
@@ -743,7 +699,7 @@ describe('Vuex', () => {
     })
 
     // mutations
-    expectedTypes('mutation').forEach(type => {
+    expectedTypes.forEach(type => {
       store.commit(type)
     })
     mutationSpys.forEach(spy => {

--- a/test/unit/test.js
+++ b/test/unit/test.js
@@ -640,6 +640,47 @@ describe('Vuex', () => {
     expect(mutationSpy).toHaveBeenCalled()
   })
 
+  it('module: use other module that has same namespace', done => {
+    const actionSpy = jasmine.createSpy()
+    const mutationSpy = jasmine.createSpy()
+
+    const store = new Vuex.Store({
+      modules: {
+        parent: {
+          namespace: 'prefix/',
+
+          modules: {
+            a: {
+              state: { value: 'a' },
+              getters: { foo: state => state.value },
+              actions: { foo: actionSpy },
+              mutations: { foo: mutationSpy }
+            },
+
+            b: {
+              state: { value: 'b' },
+              actions: {
+                test ({ dispatch, commit, getters }) {
+                  expect(getters.foo).toBe('a')
+
+                  dispatch('foo')
+                  expect(actionSpy).toHaveBeenCalled()
+
+                  commit('foo')
+                  expect(mutationSpy).toHaveBeenCalled()
+
+                  done()
+                }
+              }
+            }
+          }
+        }
+      }
+    })
+
+    store.dispatch('prefix/test')
+  })
+
   it('module: nested namespace', () => {
     // mock module generator
     const actionSpys = []

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -37,8 +37,8 @@ export declare class Store<S> {
 export declare function install(Vue: typeof _Vue): void;
 
 export interface Dispatch {
-  (type: string, payload?: any): Promise<any[]>;
-  <P extends Payload>(payloadWithType: P): Promise<any[]>;
+  (type: string, payload?: any, options?: DispatchOptions): Promise<any[]>;
+  <P extends Payload>(payloadWithType: P, options?: DispatchOptions): Promise<any[]>;
 }
 
 export interface Commit {
@@ -52,14 +52,20 @@ export interface ActionContext<S, R> {
   state: S;
   getters: any;
   rootState: R;
+  rootGetters: any;
 }
 
 export interface Payload {
   type: string;
 }
 
+export interface DispatchOptions {
+  root?: boolean;
+}
+
 export interface CommitOptions {
   silent?: boolean;
+  root?: boolean;
 }
 
 export interface StoreOptions<S> {
@@ -72,12 +78,13 @@ export interface StoreOptions<S> {
   strict?: boolean;
 }
 
-export type Getter<S, R> = (state: S, getters: any, rootState: R) => any;
+export type Getter<S, R> = (state: S, getters: any, rootState: R, rootGetters: any) => any;
 export type Action<S, R> = (injectee: ActionContext<S, R>, payload: any) => any;
 export type Mutation<S> = (state: S, payload: any) => any;
 export type Plugin<S> = (store: Store<S>) => any;
 
 export interface Module<S, R> {
+  namespace?: string;
   state?: S;
   getters?: GetterTree<S, R>;
   actions?: ActionTree<S, R>;

--- a/types/test/index.ts
+++ b/types/test/index.ts
@@ -121,6 +121,59 @@ namespace NestedModules {
   });
 }
 
+namespace NamespacedModule {
+  const store = new Vuex.Store({
+    state: { value: 0 },
+    getters: {
+      rootValue: state => state.value
+    },
+    actions: {
+      foo () {}
+    },
+    mutations: {
+      foo () {}
+    },
+    modules: {
+      a: {
+        namespace: "prefix/",
+        state: { value: 1 },
+        modules: {
+          b: {
+            state: { value: 2 }
+          },
+          c: {
+            namespace: "nested/",
+            state: { value: 3 },
+            getters: {
+              constant: () => 10,
+              count (state, getters, rootState, rootGetters) {
+                getters.constant;
+                rootGetters.rootValue;
+              }
+            },
+            actions: {
+              test ({ dispatch, commit, getters, rootGetters }) {
+                getters.constant;
+                rootGetters.rootValue;
+
+                dispatch("foo");
+                dispatch("foo", null, { root: true });
+
+                commit("foo");
+                commit("foo", null, { root: true });
+              },
+              foo () {}
+            },
+            mutations: {
+              foo () {}
+            }
+          }
+        }
+      }
+    }
+  });
+}
+
 namespace RegisterModule {
   interface RootState {
     value: number;


### PR DESCRIPTION
This PR is an implementation of #380 with update for docs and typings.
### Features
- Modules can have `namespace` option that expects `string` value.
- This option allows us to add prefix for all getters, actions and mutations in the same module, and also can inherit or nest a parent prefix (https://github.com/vuejs/vuex/issues/380#issue-181871602).
- `getters`, `dispatch` and `commit` in a namespaced module's action context will be localized. i.e. implicitly add module's namespace on their execution (https://github.com/vuejs/vuex/issues/380#issuecomment-252629629).
- `dispatch` and `commit` can receive `root` option on their last argument. If `root` option is specified, they dispatch/commit on global level (See example code in https://github.com/vuejs/vuex/issues/380#issuecomment-252629629).
- Getter functions in a namespaced module will receive localized `getters` like action context.
- Getter function will receive `rootGetters` on 4th argument.
### Implementation Details

I've add `ModuleCollection` and `Module` class to manage Vuex modules because it would be complicated to handle namespacing by plain objects. For example, it is difficult to detect runtime module's namespace on `registerModule` or `resetStore` because `_runtimeModules` is separated from the entire module structure.

In `ModuleCollection`, each `Module` is stored as tree structure that is same as the structure of modules option.

To localize `getters`, `dispatch` and `commit`, I added a proxy object and functions. The local `dispatch` and `commit` just add namespace string to action/mutation type. The local `getters` implementation is a bit tricky. To create the local `getters`, I iterate `store.getters` keys and take matched keys to the proxy object.
