### PR TITLE
Enable "state" as a valid key in getters

### DIFF
--- a/dist/vuex.js
+++ b/dist/vuex.js
@@ -199,7 +199,7 @@ var Store = function Store (options) {
 var prototypeAccessors = { state: {} };
 
 prototypeAccessors.state.get = function () {
-  return this._vm.state
+  return this._vm.$data.state
 };
 
 prototypeAccessors.state.set = function (v) {

--- a/dist/vuex.js
+++ b/dist/vuex.js
@@ -199,7 +199,7 @@ var Store = function Store (options) {
 var prototypeAccessors = { state: {} };
 
 prototypeAccessors.state.get = function () {
-  return this._vm.$data.state
+  return this._vm.state
 };
 
 prototypeAccessors.state.set = function (v) {

--- a/src/index.js
+++ b/src/index.js
@@ -53,7 +53,7 @@ class Store {
   }
 
   get state () {
-    return this._vm.state
+    return this._vm.$data.state
   }
 
   set state (v) {

--- a/test/unit/test.js
+++ b/test/unit/test.js
@@ -173,10 +173,10 @@ describe('Vuex', () => {
   it('getters', () => {
     const store = new Vuex.Store({
       state: {
-        a: 1
+        a: 0
       },
       getters: {
-        hasAny: state => state.a > 1
+        state: state => state.a > 0 ? 'hasAny' : 'none'
       },
       mutations: {
         [TEST] (state, n) {
@@ -186,17 +186,17 @@ describe('Vuex', () => {
       actions: {
         check ({ getters }, value) {
           // check for exposing getters into actions
-          expect(getters.hasAny).toBe(value)
+          expect(getters.state).toBe(value)
         }
       }
     })
-    expect(store.getters.hasAny).toBe(false)
-    store.dispatch('check', false)
+    expect(store.getters.state).toBe('none')
+    store.dispatch('check', 'none')
 
     store.commit(TEST, 1)
 
-    expect(store.getters.hasAny).toBe(true)
-    store.dispatch('check', true)
+    expect(store.getters.state).toBe('hasAny')
+    store.dispatch('check', 'hasAny')
   })
 
   it('dynamic module registration', () => {


### PR DESCRIPTION
# Issue
When I declare a `state` key in getters as follow, there is an error:
```js
const store = new Vuex.Store({
  state: {
    count: 0
  },
  getters: {
    state: state => state.count > 0 ? 'hasAny' : 'none'
  }
})
```
> Uncaught RangeError: Maximum call stack size exceeded(…)

Check out the simple [demo](https://jsfiddle.net/xiaoyanhao/4wxktgx1/) and the error will be logged in the console.

# Debug
Finally I found there will be a **circular** call if declaring `state` key in getters:

1. `Getters` is treated as computed properties and `state` as data properties (under a `state` key) in `Vuex.Store._vm`. However, in vue, if there is a same key both in `computed` and `data`, we will always get the computed property using proxied properties of the vue instance.

    ```js
    let vm = new Vue({
      data: {
        count: 0,
        state: 'I will be overwritten'
      },
      computed: {
        state: function () {
          return this.count > 0 ? 'hasAny' : 'none'
        }
      }
    })

    vm.state // 'none'
    ```
2. When getting store state, the `state` in getters is returned instead of the single state tree based on step 1.

    ```js
    class Store {
      get state () {
        return this._vm.state
      }
    }
    ```
3. Invoke the `state` getter function which will access `store.state` at first. So it jumps to step 2 and leads to a endless call stack.

    ```js
    store._wrappedGetters[getterKey] = function wrappedGetter (store) {
      return rawGetter(
        getNestedState(store.state, modulePath), // local state
        store.getters, // getters
        store.state // root state
      )
    }
    ```

# Fix
Access the store state through instance properties (prefixed with `$`) instead of proxied properties in order to avoid overlapping between data and computed properties in vue instance.
```js
class Store {
  get state () {
    // return this._vm.state
    return this._vm.$data.state // also reactive
  }
}
```