### PR TITLE
Update store.watch() typing

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -18,7 +18,7 @@ export declare class Store<S> {
   commit: Commit;
 
   subscribe<P extends Payload>(fn: (mutation: P, state: S) => any): () => void;
-  watch<T>(getter: (state: S) => T, cb: (value: T) => void, options?: WatchOptions): void;
+  watch<T>(getter: (state: S) => T, cb: (value: T, oldValue: T) => void, options?: WatchOptions): void;
 
   registerModule<T>(path: string, module: Module<T, S>): void;
   registerModule<T>(path: string[], module: Module<T, S>): void;


### PR DESCRIPTION
watch callback gives oldValue as the second parameter.
It may also be undefined in case `{immediate: true}` is used, but typing it optional could be inconvenient for most common uses.