### PR TITLE
Added example of using namespaced types

### DIFF
--- a/docs/en/modules.md
+++ b/docs/en/modules.md
@@ -83,9 +83,8 @@ const moduleA = {
 
 Note that actions, mutations and getters inside modules are still registered under the **global namespace** - this allows multiple modules to react to the same mutation/action type. You can namespace the module assets yourself to avoid name clashing by prefixing or suffixing their names. And you probably should if you are writing a reusable Vuex module that will be used in unknown environments. For example, we want to create a `todos` module:
 
+###### types.js
 ``` js
-// types.js
-
 // define names of getters, actions and mutations as constants
 // and they are prefixed by the module name `todos`
 export const DONE_COUNT = 'todos/DONE_COUNT'
@@ -93,8 +92,8 @@ export const FETCH_ALL = 'todos/FETCH_ALL'
 export const TOGGLE_DONE = 'todos/TOGGLE_DONE'
 ```
 
+###### modules/todos.js
 ``` js
-// modules/todos.js
 import * as types from '../types'
 
 // define getters, actions and mutations using prefixed names
@@ -119,6 +118,27 @@ const todosModule = {
     }
   }
 }
+```
+
+###### components/SomeComponent.vue  
+``` js
+<script>
+import { mapGetters, mapActions } from 'vuex'
+import * as types from '../types'
+
+export default {
+  computed: {
+    ...mapGetters({
+      doneCount: types.DONE_COUNT
+    })
+  },
+  methods: {
+    ...mapActions({
+      fetchAllTodos: types.FETCH_ALL
+    })
+  }
+}
+</script>
 ```
 
 ### Dynamic Module Registration

--- a/docs/fr/modules.md
+++ b/docs/fr/modules.md
@@ -83,9 +83,8 @@ const moduleA = {
 
 Notez que les actions, mutations et getters dans un module sont toujours enregistrés sous le **namespace global** &mdash; cela permet à plusieurs modules de réagir au même type de mutation/action. Vous pouvez répartir les modules dans des namespaces vous-mêmes afin d'éviter les conflits de nom en préfixant ou suffixant leurs noms. Et vous devriez probablement faire cela si vous utiliser un module Vuex réutilisable qui sera utilisé dans des environnements inconnus. Par exemple, nous voulons créer un module `todos` :
 
+###### types.js
 ``` js
-// types.js
-
 // on définit les noms des getters, actions et mutations en tant que constantes
 // et on les préfixe du nom du module `todos`
 export const DONE_COUNT = 'todos/DONE_COUNT'
@@ -93,8 +92,8 @@ export const FETCH_ALL = 'todos/FETCH_ALL'
 export const TOGGLE_DONE = 'todos/TOGGLE_DONE'
 ```
 
+###### modules/todos.js
 ``` js
-// modules/todos.js
 import * as types from '../types'
 
 // on définit les getters, actions et mutations en utilisant des noms préfixés
@@ -119,6 +118,27 @@ const todosModule = {
     }
   }
 }
+```
+
+###### components/SomeComponent.vue  
+``` js
+<script>
+import { mapGetters, mapActions } from 'vuex'
+import * as types from '../types'
+
+export default {
+  computed: {
+    ...mapGetters({
+      doneCount: types.DONE_COUNT
+    })
+  },
+  methods: {
+    ...mapActions({
+      fetchAllTodos: types.FETCH_ALL
+    })
+  }
+}
+</script>
 ```
 
 ### Enregistrement dynamique de module

--- a/docs/ru/modules.md
+++ b/docs/ru/modules.md
@@ -83,9 +83,8 @@ const moduleA = {
 
 Обратите внимание, что действия, мутации и геттеры, определённые внутри модулей, тем не менее регистрируются в **глобальном пространстве имён** — это позволяет нескольким модулям реагировать на один и тот же тип мутации или действия. Избежать конфликта пространства имён вы можете, указывая для них префикс или суффикс. При создании пригодных для повторного использования модулей Vuex, пожалуй, так поступать даже нужно — кто знает, в каком окружении их будут использовать? Например, предположим что мы создаём модуль `todos`:
 
+###### types.js
 ``` js
-// types.js
-
 // определим названия геттеров, действий и мутаций как константы
 // используя название модуля (`todos`) в качестве префикса
 export const DONE_COUNT = 'todos/DONE_COUNT'
@@ -93,8 +92,8 @@ export const FETCH_ALL = 'todos/FETCH_ALL'
 export const TOGGLE_DONE = 'todos/TOGGLE_DONE'
 ```
 
+###### modules/todos.js
 ``` js
-// modules/todos.js
 import * as types from '../types'
 
 // теперь используем определённые выше константы
@@ -119,6 +118,27 @@ const todosModule = {
     }
   }
 }
+```
+
+###### components/SomeComponent.vue  
+``` js
+<script>
+import { mapGetters, mapActions } from 'vuex'
+import * as types from '../types'
+
+export default {
+  computed: {
+    ...mapGetters({
+      doneCount: types.DONE_COUNT
+    })
+  },
+  methods: {
+    ...mapActions({
+      fetchAllTodos: types.FETCH_ALL
+    })
+  }
+}
+</script>
 ```
 
 ### Динамическая регистрация модулей

--- a/docs/zh-cn/modules.md
+++ b/docs/zh-cn/modules.md
@@ -83,17 +83,16 @@ const moduleA = {
 
 模块内部的 action、mutation、和 getter 现在仍然注册在**全局命名空间**——这样保证了多个模块能够响应同一 mutation 或 action。你可以通过添加前缀或后缀的方式隔离各模块，以避免名称冲突。你也可能希望写出一个可复用的模块，其使用环境不可控。例如，我们想创建一个 `todos` 模块：
 
+###### types.js
 ``` js
-// types.js
-
 // 定义 getter、action、和 mutation 的名称为常量，以模块名 `todos` 为前缀
 export const DONE_COUNT = 'todos/DONE_COUNT'
 export const FETCH_ALL = 'todos/FETCH_ALL'
 export const TOGGLE_DONE = 'todos/TOGGLE_DONE'
 ```
 
+###### modules/todos.js
 ``` js
-// modules/todos.js
 import * as types from '../types'
 
 // 使用添加了前缀的名称定义 getter、action 和 mutation
@@ -118,6 +117,27 @@ const todosModule = {
     }
   }
 }
+```
+
+###### components/SomeComponent.vue  
+``` js
+<script>
+import { mapGetters, mapActions } from 'vuex'
+import * as types from '../types'
+
+export default {
+  computed: {
+    ...mapGetters({
+      doneCount: types.DONE_COUNT
+    })
+  },
+  methods: {
+    ...mapActions({
+      fetchAllTodos: types.FETCH_ALL
+    })
+  }
+}
+</script>
 ```
 
 ### 模块动态注册

--- a/examples/index.html
+++ b/examples/index.html
@@ -13,6 +13,7 @@
       <li><a href="shopping-cart">Shopping Cart</a></li>
       <li><a href="todomvc">TodoMVC</a></li>
       <li><a href="chat">FluxChat</a></li>
+      <li><a href="namespaced-types">Namespaced types</a></li>
     </ul>
   </body>
 </html>

--- a/examples/namespaced-types/app.js
+++ b/examples/namespaced-types/app.js
@@ -1,0 +1,12 @@
+import 'babel-polyfill'
+import Vue from 'vue'
+import App from './components/App.vue'
+import store from './store/store'
+
+Vue.config.debug = true
+
+new Vue({
+  el: '#app',
+  store,
+  render: h => h(App)
+})

--- a/examples/namespaced-types/components/App.vue
+++ b/examples/namespaced-types/components/App.vue
@@ -1,9 +1,9 @@
 <template>
   <form @submit.prevent="handleFormSubmit">
-  <fieldset>
-    <legend>Your username is: '{{ username }}'</legend>
-    <input type="text" name="username" placeholder="Change username..." required>
-    <input type="submit">
+    <fieldset>
+      <legend>Your username is: '{{ username }}'</legend>
+      <input type="text" name="username" placeholder="Change username..." required>
+      <input type="submit">
     </fieldset>
   </form>
 </template>

--- a/examples/namespaced-types/components/App.vue
+++ b/examples/namespaced-types/components/App.vue
@@ -1,0 +1,30 @@
+<template>
+  <form @submit.prevent="handleFormSubmit">
+  <fieldset>
+    <legend>Your username is: '{{ username }}'</legend>
+    <input type="text" name="username" placeholder="Change username..." required>
+    <input type="submit">
+    </fieldset>
+  </form>
+</template>
+
+<script>
+import { mapActions, mapGetters } from 'vuex'
+import * as userTypes from '../store/modules/user/types'
+
+export default {
+  methods: {
+    ...mapActions({
+      changeUsername: userTypes.CHANGE_USERNAME
+    }),
+    handleFormSubmit(e) {
+      this.changeUsername(e.target.username.value)
+    }
+  },
+  computed: {
+    ...mapGetters({
+      username: userTypes.USERNAME
+    })
+  }
+}
+</script>

--- a/examples/namespaced-types/index.html
+++ b/examples/namespaced-types/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8">
     <title>vuex namespaced types example</title>
-    <link href="http://fonts.googleapis.com/css?family=Muli" rel="stylesheet" type="text/css">
   </head>
   <body>
     <div id="app"></div>

--- a/examples/namespaced-types/index.html
+++ b/examples/namespaced-types/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>vuex namespaced types example</title>
+    <link href="http://fonts.googleapis.com/css?family=Muli" rel="stylesheet" type="text/css">
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="/__build__/shared.js"></script>
+    <script src="/__build__/namespaced-types.js"></script>
+  </body>
+</html>

--- a/examples/namespaced-types/store/modules/user/index.js
+++ b/examples/namespaced-types/store/modules/user/index.js
@@ -1,0 +1,20 @@
+import * as userTypes from './types'
+
+export default {
+  state: {
+    username: 'BillGates'
+  },
+  mutations: {
+    [userTypes.CHANGE_USERNAME](state, { username }) {
+      state.username = username
+    }
+  },
+  actions: {
+    [userTypes.CHANGE_USERNAME]({ commit }, username) {
+      commit(userTypes.CHANGE_USERNAME, { username })
+    }
+  },
+  getters: {
+    [userTypes.USERNAME]: state => state.username,
+  }
+}

--- a/examples/namespaced-types/store/modules/user/types.js
+++ b/examples/namespaced-types/store/modules/user/types.js
@@ -1,0 +1,2 @@
+export const USERNAME = 'user/USERNAME'
+export const CHANGE_USERNAME = 'user/CHANGE_USERNAME'

--- a/examples/namespaced-types/store/store.js
+++ b/examples/namespaced-types/store/store.js
@@ -1,0 +1,24 @@
+import Vue from 'vue'
+import Vuex from 'vuex'
+import createLogger from '../../../src/plugins/logger'
+import user from './modules/user'
+
+Vue.use(Vuex)
+
+const state = {}
+const getters = {}
+const actions = {}
+const mutations = {}
+
+export default new Vuex.Store({
+  state,
+  getters,
+  actions,
+  mutations,
+  modules: {
+    user
+  },
+  plugins: process.env.NODE_ENV !== 'production'
+    ? [createLogger()]
+    : []
+})


### PR DESCRIPTION
This PR adds an example of how you would go about implementing enumerable types for your vuex actions, getters and mutations with namespace prefixes so they don't collide in the global vuex namespace.