### PR TITLE
Add store getters as second argument to store.watch() computed fn (solve #460)

### DIFF
--- a/dist/vuex.js
+++ b/dist/vuex.js
@@ -199,7 +199,7 @@ var Store = function Store (options) {
 var prototypeAccessors = { state: {} };
 
 prototypeAccessors.state.get = function () {
-  return this._vm.state
+  return this._vm.$data.state
 };
 
 prototypeAccessors.state.set = function (v) {
@@ -264,7 +264,7 @@ Store.prototype.watch = function watch (getter, cb, options) {
     var this$1 = this;
 
   assert(typeof getter === 'function', "store.watch only accepts a function.")
-  return this._watcherVM.$watch(function () { return getter(this$1.state); }, cb, options)
+  return this._watcherVM.$watch(function () { return getter(this$1.state, this$1.getters); }, cb, options)
 };
 
 Store.prototype.replaceState = function replaceState (state) {

--- a/dist/vuex.js
+++ b/dist/vuex.js
@@ -199,7 +199,7 @@ var Store = function Store (options) {
 var prototypeAccessors = { state: {} };
 
 prototypeAccessors.state.get = function () {
-  return this._vm.$data.state
+  return this._vm.state
 };
 
 prototypeAccessors.state.set = function (v) {
@@ -264,7 +264,7 @@ Store.prototype.watch = function watch (getter, cb, options) {
     var this$1 = this;
 
   assert(typeof getter === 'function', "store.watch only accepts a function.")
-  return this._watcherVM.$watch(function () { return getter(this$1.state, this$1.getters); }, cb, options)
+  return this._watcherVM.$watch(function () { return getter(this$1.state); }, cb, options)
 };
 
 Store.prototype.replaceState = function replaceState (state) {

--- a/src/index.js
+++ b/src/index.js
@@ -114,7 +114,7 @@ class Store {
 
   watch (getter, cb, options) {
     assert(typeof getter === 'function', `store.watch only accepts a function.`)
-    return this._watcherVM.$watch(() => getter(this.state), cb, options)
+    return this._watcherVM.$watch(() => getter(this.state, this.getters), cb, options)
   }
 
   replaceState (state) {

--- a/test/unit/test.js
+++ b/test/unit/test.js
@@ -5,7 +5,7 @@ import Vuex, { mapState, mapMutations, mapGetters, mapActions } from '../../dist
 Vue.use(Vuex)
 
 const TEST = 'TEST'
-const TEST2 = 'TEST2'
+// const TEST2 = 'TEST2'
 
 describe('Vuex', () => {
   it('committing mutations', () => {
@@ -1013,6 +1013,38 @@ describe('Vuex', () => {
 
       Vue.nextTick(() => {
         expect(spy).toHaveBeenCalled()
+        done()
+      })
+    })
+  })
+
+  it('watch: getter function has access to store\'s getters object', done => {
+    const store = new Vuex.Store({
+      state: {
+        count: 0
+      },
+      mutations: {
+        [TEST]: state => state.count++
+      },
+      getters: {
+        getCount: state => state.count
+      }
+    })
+
+    const getter = function getter (state, getters) {
+      return state.count
+    }
+    const spy = spyOn({ getter }, 'getter').and.callThrough()
+    const spyCb = jasmine.createSpy()
+
+    store.watch(spy, spyCb)
+
+    Vue.nextTick(() => {
+      store.commit(TEST)
+      expect(store.state.count).toBe(1)
+
+      Vue.nextTick(() => {
+        expect(spy).toHaveBeenCalledWith(store.state, store.getters)
         done()
       })
     })

--- a/test/unit/test.js
+++ b/test/unit/test.js
@@ -5,7 +5,6 @@ import Vuex, { mapState, mapMutations, mapGetters, mapActions } from '../../dist
 Vue.use(Vuex)
 
 const TEST = 'TEST'
-// const TEST2 = 'TEST2'
 
 describe('Vuex', () => {
   it('committing mutations', () => {


### PR DESCRIPTION
* the first parameter of store.watch(), which is a function, now receives the store.getters object as its second argument.
* added unit test

Fullfills request #460