### PR TITLE
[v1.0] Assert dispatched type

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -106,6 +106,13 @@ class Store {
       if (type.silent) silent = true
       type = type.type
     }
+
+    if (typeof type !== 'string') {
+      throw new Error(
+        `Expects string as the type, but found ${typeof type}.`
+      )
+    }
+
     const handler = this._mutations[type]
     const state = this.state
     if (handler) {

--- a/src/index.js
+++ b/src/index.js
@@ -109,7 +109,7 @@ class Store {
 
     if (typeof type !== 'string') {
       throw new Error(
-        `Expects string as the type, but found ${typeof type}.`
+        `[vuex] Expects string as the type, but found ${typeof type}.`
       )
     }
 

--- a/test/unit/test.js
+++ b/test/unit/test.js
@@ -26,6 +26,25 @@ describe('Vuex', () => {
     expect(store.state.a).to.equal(3)
   })
 
+  it('throws for dispatch with undefined type', () => {
+    const store = new Vuex.Store({
+      state: {
+        a: 1
+      },
+      mutations: {
+        // Maybe registered with undefined type accidentally
+        // if the user has typo in a constant type
+        undefined (state, n) {
+          state.a += n
+        }
+      }
+    })
+    expect(() => {
+      store.dispatch(undefined, 2)
+    }).to.throw(/Expects string as the type, but found undefined/)
+    expect(store.state.a).to.equal(1)
+  })
+
   it('injecting state and action to components', function () {
     const store = new Vuex.Store({
       state: {


### PR DESCRIPTION
As pointed out in #538, we may register `undefined` mutation and accidentally dispatch it if we have typo in constant types.

I've added assertion in dispatch method to avoid and can be aware the mistake.