### PR TITLE
accept a function for the initial state

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,8 @@ class Store {
     assert(Vue, `must call Vue.use(Vuex) before creating a store instance.`)
     assert(typeof Promise !== 'undefined', `vuex requires a Promise polyfill in this browser.`)
 
+    if ( typeof options.state === 'function' ) options.state = options.state();
+
     const {
       state = {},
       plugins = [],
@@ -232,7 +234,11 @@ function installModule (store, rootState, path, module, hot) {
     const parentState = getNestedState(rootState, path.slice(0, -1))
     const moduleName = path[path.length - 1]
     store._withCommit(() => {
-      Vue.set(parentState, moduleName, module.state)
+      Vue.set(
+        parentState,
+        moduleName, 
+        ( typeof module.state === 'function' ) ? module.state() : module.state
+      )
     })
   }
 


### PR DESCRIPTION
More of a RFC than a real PR, as it needs tests and documentation, but a naive stab at dealing with cases where we'd like to have a fresh state each time we create a new store.

For example:

```
import Vuex from 'vuex';
import Vue from 'vue';

Vue.use(Vuex);

let baz = {
    state: { quux: 21 },
    mutations: { 'inner': state => state.quux++ },
};

let new_store = () => new Vuex.Store({
    state: () => { foo: 12 },
    mutations: {
        'bar': state => state.foo++
    },
    modules: { baz },
});

let store = new_store();

store.commit('inner');
store.commit('bar');

console.log( JSON.stringify( store.state ) );
// { foo: 13, quux: 22 }

store = new_store();

store.commit('inner');
store.commit('bar');

console.log( JSON.stringify( store.state ) );
// OOPS! { foo: 13, quux: 23 }
```

To get around that, I allow for the initial state to be generated by a given function, like it is done in Redux.