### PR TITLE
Extend plugin functionalities

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -49,8 +49,23 @@ class Store {
     // (also registers _wrappedGetters as computed properties)
     resetStoreVM(this, state)
 
+    const me = this
+    function registerInContext (name, key, val) {
+      let context = me.context
+      // swap variables if first arg is empty (registering into the root store)
+      if (val === undefined) {
+        val = key
+        key = name
+      } else {
+        context = me._modules.get(name.split('.')).context
+      }
+      context[key] = val
+    }
+
     // apply plugins
-    plugins.concat(devtoolPlugin).forEach(plugin => plugin(this))
+    plugins.concat(devtoolPlugin).forEach(plugin => plugin(this, {
+      registerInContext
+    }))
   }
 
   get state () {
@@ -236,7 +251,7 @@ function installModule (store, rootState, path, module, hot) {
     })
   }
 
-  const local = module.context = makeLocalContext(store, namespace, path)
+  const local = (isRoot ? store : module).context = makeLocalContext(store, namespace, path)
 
   module.forEachMutation((mutation, key) => {
     const namespacedType = namespace + key
@@ -348,14 +363,18 @@ function registerMutation (store, type, handler, local) {
 function registerAction (store, type, handler, local) {
   const entry = store._actions[type] || (store._actions[type] = [])
   entry.push(function wrappedActionHandler (payload, cb) {
-    let res = handler({
-      dispatch: local.dispatch,
-      commit: local.commit,
+    const context = {
       getters: local.getters,
       state: local.state,
       rootGetters: store.getters,
       rootState: store.state
-    }, payload, cb)
+    }
+    // bring in commit, dispatch and any other added property
+    // Use this because IE doesn't supprot Object.assign
+    for (const key in local) {
+      context[key] = local[key]
+    }
+    let res = handler(context, payload, cb)
     if (!isPromise(res)) {
       res = Promise.resolve(res)
     }

--- a/test/unit/modules.spec.js
+++ b/test/unit/modules.spec.js
@@ -465,34 +465,5 @@ describe('Modules', () => {
         done()
       })
     })
-
-    it('plugins', function () {
-      let initState
-      const mutations = []
-      const store = new Vuex.Store({
-        state: {
-          a: 1
-        },
-        mutations: {
-          [TEST] (state, n) {
-            state.a += n
-          }
-        },
-        plugins: [
-          store => {
-            initState = store.state
-            store.subscribe((mut, state) => {
-              expect(state).toBe(store.state)
-              mutations.push(mut)
-            })
-          }
-        ]
-      })
-      expect(initState).toBe(store.state)
-      store.commit(TEST, 2)
-      expect(mutations.length).toBe(1)
-      expect(mutations[0].type).toBe(TEST)
-      expect(mutations[0].payload).toBe(2)
-    })
   })
 })

--- a/test/unit/plugins.spec.js
+++ b/test/unit/plugins.spec.js
@@ -1,0 +1,83 @@
+import Vue from 'vue/dist/vue.common.js'
+import Vuex from '../../dist/vuex.js'
+
+const TEST = 'TEST'
+
+describe('Plugins', () => {
+  it('executes plugins function', function () {
+    let initState
+    const mutations = []
+    const store = new Vuex.Store({
+      state: {
+        a: 1
+      },
+      mutations: {
+        [TEST] (state, n) {
+          state.a += n
+        }
+      },
+      plugins: [
+        store => {
+          initState = store.state
+          store.subscribe((mut, state) => {
+            expect(state).toBe(store.state)
+            mutations.push(mut)
+          })
+        }
+      ]
+    })
+    expect(initState).toBe(store.state)
+    store.commit(TEST, 2)
+    expect(mutations.length).toBe(1)
+    expect(mutations[0].type).toBe(TEST)
+    expect(mutations[0].payload).toBe(2)
+  })
+
+  it('can inject into store context', async function (done) {
+    const store = new Vuex.Store({
+      state: { a: 1 },
+      actions: {
+        useFoo: ({ foo }) => foo
+      },
+      modules: {
+        module: {
+          actions: {
+            moduleAction: ({ foo }) => foo
+          }
+        }
+      },
+      plugins: [
+        (store, { registerInContext }) => {
+          registerInContext('foo', 'foo')
+        }
+      ]
+    })
+    expect(await store.dispatch('useFoo')).toBe('foo')
+    expect(await store.dispatch('moduleAction')).toBe(undefined)
+    done()
+  })
+
+  it('can inject into modules context', async function (done) {
+    const store = new Vuex.Store({
+      state: { a: 1 },
+      actions: {
+        useFoo: ({ foo }) => foo
+      },
+      modules: {
+        module: {
+          actions: {
+            moduleAction: ({ foo }) => foo
+          }
+        }
+      },
+      plugins: [
+        (store, { registerInContext }) => {
+          registerInContext('module', 'foo', 'foo')
+        }
+      ]
+    })
+    expect(await store.dispatch('moduleAction')).toBe('foo')
+    expect(await store.dispatch('useFoo')).toBe(undefined)
+    done()
+  })
+})

--- a/test/unit/plugins.spec.js
+++ b/test/unit/plugins.spec.js
@@ -33,7 +33,7 @@ describe('Plugins', () => {
     expect(mutations[0].payload).toBe(2)
   })
 
-  it('can inject into store context', async function (done) {
+  it('injects into store context', async function (done) {
     const store = new Vuex.Store({
       state: { a: 1 },
       actions: {
@@ -57,7 +57,7 @@ describe('Plugins', () => {
     done()
   })
 
-  it('can inject into modules context', async function (done) {
+  it('injects into modules context', async function (done) {
     const store = new Vuex.Store({
       state: { a: 1 },
       actions: {
@@ -78,6 +78,37 @@ describe('Plugins', () => {
     })
     expect(await store.dispatch('moduleAction')).toBe('foo')
     expect(await store.dispatch('useFoo')).toBe(undefined)
+    done()
+  })
+
+  it('injects actions bounded to root', async function (done) {
+    const store = new Vuex.Store({
+      state: { a: 1 },
+      plugins: [
+        (store, { registerAction }) => {
+          registerAction('stateA', ({ state }) => state.a)
+        }
+      ]
+    })
+    expect(await store.dispatch('stateA')).toBe(1)
+    done()
+  })
+
+  it('injects actions bounded to a module', async function (done) {
+    const store = new Vuex.Store({
+      state: { a: 1 },
+      modules: {
+        module: {
+          state: { a: 2 }
+        }
+      },
+      plugins: [
+        (store, { registerAction }) => {
+          registerAction('module', 'stateA', ({ state }) => state.a)
+        }
+      ]
+    })
+    expect(await store.dispatch('stateA')).toBe(2)
     done()
   })
 })


### PR DESCRIPTION
# WIP

The idea of this PR is to give plugins more than just subscribing:

- Adding anything to the context passed to actions. This would allow constants or custom methods and can be useful to integrate a Database or Service like firebase.
- Adding new actions
- Adding new getters
- Adding new mutations

There's no need to add something to the state because it can be achieved by doing `Vue.set(store.state, key, value)`. Although this should be pointed out in the docs

---

The content of this PR is still **unfinished** so we can iterate over the API before releasing it

---

## API proposal

### Adding properties to the context

Using functions allow to let the plugin check the path and use the context:

```js
// multiple names are possible like assignContext, mergeContext, registerInContext, etc
mergeInContext((modulePath, context) => {
  // path is an array of strings: ['some', 'module']
  // Only registers for some/module
  if (modulePath.join('/') === 'some/module') {
    return {
      foo: 'staticProperty',
      bindRef () {
        context.commit(modulePath.join('/') + '/myPlugin/MUTATION')
      }
    }
  }
})

// registering in every context (most of the time)
mergeInContext((modulePath, context) => ({
  foo: 'staticProperty',
  bindRef () { // a function }
}))
```

This needs some kind of `walk` method on **Module**s that recursively invoke a
function. **ModuleCollection**'s `walk` can simple be called on the root module

Then we can use the merged data in actions:

```js
// merging properties directly into context
function someAction ({ commit, foo, bindRef }) {
  foo === 'staticProperty'
  bindRef()
}

// OR merging them in a plugins property
function someAction ({ commit, plugins: { foo, bindRef } }) {
  foo === 'staticProperty'
  bindRef()
}

// OR forcing a first parameter as the name of the plugin
// this name should not override existinting properties or at least
// display a warning
function someAction ({ commit, firebase: { foo, bindRef } }) {
  foo === 'staticProperty'
  bindRef()
}
```

Merging in a `plugins` property would prevent plugins to break with future
releases of Vuex (as pointed out by @ktsn) but also make it impossible for them
to overwrite the commit function or any other

### Adding actions, mutations and getters

Differently from adding to context, when adding actions, mutations or getters,
you may want to add them to a specific module (imagine something like `plugins: [MyPlugin('moduleA', 'moduleB').
You may also want to add it to every module existing. This would be
the case for VuexFire, allowing it to use the context-specific commit functions
to allow the user to bind firebase references in any module.

```js
// We should use the same name of context
mergeInModule((modulePath, context) => ({
  mutations: {
    // Dynamic names
    [`${modulePath.join('/')}/myPluginName/MUTATION`] (state) { // state.foo = 'bar' }
  }
}))
```

I'm not sure about what to do with the namespace. I think not using it may be
safer since plugins relying on it to register different mutations would fail


Extra things in this PR:

- Added a context to the rootStore (same as modules) accessible as store.context
- Moved plugin test to `plugin.spec.js`