### PR TITLE
Mini fix in rootState example.

### DIFF
--- a/docs/en/modules.md
+++ b/docs/en/modules.md
@@ -58,7 +58,7 @@ const moduleA = {
   // ...
   actions: {
     incrementIfOddOnRootSum ({ state, commit, rootState }) {
-      if (state.count + rootState.count % 2 === 1) {
+      if ((state.count + rootState.count % 2) === 1) {
         commit('increment')
       }
     }

--- a/docs/en/modules.md
+++ b/docs/en/modules.md
@@ -58,7 +58,7 @@ const moduleA = {
   // ...
   actions: {
     incrementIfOddOnRootSum ({ state, commit, rootState }) {
-      if ((state.count + rootState.count % 2) === 1) {
+      if ((state.count + rootState.count) % 2 === 1) {
         commit('increment')
       }
     }


### PR DESCRIPTION
Maybe I misunderstood the example, but without parenthesis the `%` operator will be executed before the `+`.