### PR TITLE
Explain that `mapActions` supports payloads

### DIFF
--- a/docs/en/actions.md
+++ b/docs/en/actions.md
@@ -107,7 +107,10 @@ export default {
   // ...
   methods: {
     ...mapActions([
-      'increment' // map this.increment() to this.$store.dispatch('increment')
+      'increment', // map this.increment() to this.$store.dispatch('increment')
+      
+      // mapActions also supports payloads:
+      'incrementBy' // this.incrementBy(amount) maps to this.$store.dispatch('incrementBy', amount)
     ]),
     ...mapActions({
       add: 'increment' // map this.add() to this.$store.dispatch('increment')


### PR DESCRIPTION
I was looking for this information, googled, and landed in #611. 

So I opened this PR to add a line to the docs that explains this.