### PR TITLE
Update typings

### DIFF
--- a/types/helpers.d.ts
+++ b/types/helpers.d.ts
@@ -1,4 +1,4 @@
-import Vue = require("vue");
+import Vue from "vue";
 
 type Dictionary<T> = { [key: string]: T };
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,8 +1,13 @@
-import _Vue = require("vue");
+import _Vue from "vue";
 import { WatchOptions } from "vue";
 
 // augment typings of Vue.js
 import "./vue";
+
+export default {
+  Store,
+  install
+};
 
 export * from "./helpers";
 

--- a/types/test/helpers.ts
+++ b/types/test/helpers.ts
@@ -1,4 +1,4 @@
-import Vue = require("vue");
+import Vue from "vue";
 
 import {
   mapState,

--- a/types/test/index.ts
+++ b/types/test/index.ts
@@ -1,4 +1,4 @@
-import Vue = require("vue");
+import Vue from "vue";
 import * as Vuex from "../index";
 import createLogger from "../../dist/logger";
 

--- a/types/test/vue.ts
+++ b/types/test/vue.ts
@@ -1,5 +1,5 @@
-import Vue = require("vue");
-import * as Vuex from "../index";
+import Vue from "vue";
+import Vuex from "../index";
 
 const store = new Vuex.Store({
   state: {

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -2,7 +2,7 @@
  * Extends interfaces in Vue.js
  */
 
-import Vue = require("vue");
+import Vue from "vue";
 import { Store } from "./index";
 
 declare module "vue/types/options" {


### PR DESCRIPTION
Depends on https://github.com/vuejs/vue/pull/5016

This also adds a default export object so that the following usage will be consistent in both ES and TS:

``` js
import Vue from 'vue'
import Vuex from 'vuex'

Vue.use(Vuex)

const store = new Vuex.Store({
  // ...
})
```