### PR TITLE
Implement #651 multiple mutations

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -293,6 +293,16 @@ function makeLocalContext (store, namespace, path) {
     },
 
     commit: noNamespace ? store.commit : (_type, _payload, _options) => {
+      if (Array.isArray(_type)) {
+        _type.forEach(mutation => {
+          if (typeof mutation === 'string') {
+            local.commit(mutation, null, _payload)
+          } else {
+            local.commit(mutation, _payload)
+          }
+        })
+        return
+      }
       const args = unifyObjectStyle(_type, _payload, _options)
       const { payload, options } = args
       let { type } = args

--- a/src/store.js
+++ b/src/store.js
@@ -61,6 +61,13 @@ export class Store {
   }
 
   commit (_type, _payload, _options) {
+    if (Array.isArray(_type)) {
+      _type.forEach(mutation => {
+        this.commit(mutation)
+      })
+      return
+    }
+
     // check object-style commit
     const {
       type,

--- a/src/store.js
+++ b/src/store.js
@@ -295,11 +295,7 @@ function makeLocalContext (store, namespace, path) {
     commit: noNamespace ? store.commit : (_type, _payload, _options) => {
       if (Array.isArray(_type)) {
         _type.forEach(mutation => {
-          if (typeof mutation === 'string') {
-            local.commit(mutation, null, _payload)
-          } else {
-            local.commit(mutation, _payload)
-          }
+          local.commit(mutation, _payload, _payload)
         })
         return
       }

--- a/test/unit/modules.spec.js
+++ b/test/unit/modules.spec.js
@@ -408,6 +408,18 @@ describe('Modules', () => {
                 commit('foo', null, { root: true })
                 expect(rootMutationSpy.calls.count()).toBe(1)
 
+                moduleMutationSpy.calls.reset()
+                commit(['foo', 'foo'])
+                expect(moduleMutationSpy.calls.count()).toBe(2)
+
+                rootMutationSpy.calls.reset()
+                commit(['foo', 'foo'], { root: true })
+                expect(rootMutationSpy.calls.count()).toBe(2)
+
+                rootMutationSpy.calls.reset()
+                commit([{ type: 'foo' }, { type: 'foo' }], { root: true })
+                expect(rootMutationSpy.calls.count()).toBe(2)
+
                 done()
               }
             },

--- a/test/unit/store.spec.js
+++ b/test/unit/store.spec.js
@@ -37,6 +37,27 @@ describe('Store', () => {
     expect(store.state.a).toBe(3)
   })
 
+  it('committing with array style multiple mutations', () => {
+    const store = new Vuex.Store({
+      state: {
+        a: 1
+      },
+      mutations: {
+        [TEST] (state, payload) {
+          state.a += payload.amount
+        }
+      }
+    })
+    store.commit([{
+      type: TEST,
+      amount: 1
+    }, {
+      type: TEST,
+      amount: 2
+    }])
+    expect(store.state.a).toBe(4)
+  })
+
   it('asserts committed type', () => {
     const store = new Vuex.Store({
       state: {


### PR DESCRIPTION
I implemented the multiple mutations committing feature (#651). So now you can commit multiple mutations with an array.

```js
store.commit([{
  type: 'ADD',
  amount: 1
}, {
  type: 'ADD',
  amount: 2
}])

// equals to
store.commit({
  type: 'ADD',
  amount: 1
})
store.commit({
  type: 'ADD',
  amount: 2
})
```

This will also work: 

```js
store.commit(['INCREMENT', 'INCREMENT', 'INCREMENT'])

// equals to
store.commit('INCREMENT')
store.commit('INCREMENT')
store.commit('INCREMENT')
```