### PR TITLE
avoid to get wrong state with mapState

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -226,9 +226,7 @@ function installModule (store, rootState, path, module, hot) {
   const namespace = store._modules.getNamespace(path)
 
   // register in namespace map
-  // it should not be registered if namespaced === false
-  // because nested modules can have the same namespace as a parent module
-  if (module.namespaced && namespace) {
+  if (module.namespaced) {
     store._modulesNamespaceMap[namespace] = module
   }
 

--- a/src/store.js
+++ b/src/store.js
@@ -226,7 +226,9 @@ function installModule (store, rootState, path, module, hot) {
   const namespace = store._modules.getNamespace(path)
 
   // register in namespace map
-  if (namespace) {
+  // it should not be registered if namespaced === false
+  // because nested modules can have the same namespace as a parent module
+  if (module.namespaced && namespace) {
     store._modulesNamespaceMap[namespace] = module
   }
 

--- a/test/unit/helpers.spec.js
+++ b/test/unit/helpers.spec.js
@@ -68,6 +68,32 @@ describe('Helpers', () => {
     expect(vm.a).toBe(7)
   })
 
+  // #708
+  it('mapState (with namespace and a nested module)', () => {
+    const store = new Vuex.Store({
+      modules: {
+        foo: {
+          namespaced: true,
+          state: { a: 1 },
+          modules: {
+            bar: {
+              state: { b: 2 }
+            }
+          }
+        }
+      }
+    })
+    const vm = new Vue({
+      store,
+      computed: mapState('foo', {
+        value: state => state
+      })
+    })
+    expect(vm.value.a).toBe(1)
+    expect(vm.value.bar.b).toBe(2)
+    expect(vm.value.b).toBeUndefined()
+  })
+
   it('mapMutations (array)', () => {
     const store = new Vuex.Store({
       state: { count: 0 },


### PR DESCRIPTION
Fix #708 

If the store has a namespaced module X that has a non-namespaced module Y, `mapState` helper can get a wrong state.

This is because X and Y has the same namespace due to inheritance. Then module X in `_modulesNamespaceMap` is overwritten by Y.

This PR limits only `namespaced === true` modules can be registered in `_modulesNamespaceMap` to avoid this behavior.