### PR TITLE
Testing doc page - Add '-loader' suffix to webpack config

### DIFF
--- a/docs/en/testing.md
+++ b/docs/en/testing.md
@@ -189,7 +189,7 @@ module.exports = {
     loaders: [
       {
         test: /\.js$/,
-        loader: 'babel',
+        loader: 'babel-loader',
         exclude: /node_modules/
       }
     ]


### PR DESCRIPTION
When copy / pasting the webpack configuration given in the 'Testing' doc page, I end up with following error:
`ERROR in Entry module not found: Error: Can't resolve 'babel' in '<...>'`
`BREAKING CHANGE: It's no longer allowed to omit the '-loader' suffix when using loaders.`
`You need to specify 'babel-loader' instead of 'babel'.`
My version of webpack: 2.2.0-rc.3
Adding the '-loader' suffix fixed the problem.
Not sure though how safe it is to use 'babel-loader' instead of 'babel' with previous webpack versions...