### PR TITLE
Pass original mutation to subscribers on object-style commit

### DIFF
--- a/dist/vuex.js
+++ b/dist/vuex.js
@@ -311,8 +311,8 @@ Store.prototype.commit = function commit (_type, _payload, _options) {
     var type = ref.type;
     var payload = ref.payload;
     var options = ref.options;
+    var mutation = ref.mutation;
 
-  var mutation = { type: type, payload: payload };
   var entry = this._mutations[type];
   if (!entry) {
     console.error(("[vuex] unknown mutation type: " + type));
@@ -476,7 +476,7 @@ function installModule (store, rootState, path, module, hot) {
   var namespace = store._modules.getNamespace(path);
 
   // register in namespace map
-  if (namespace) {
+  if (module.namespaced) {
     store._modulesNamespaceMap[namespace] = module;
   }
 
@@ -653,7 +653,9 @@ function getNestedState (state, path) {
 }
 
 function unifyObjectStyle (type, payload, options) {
+  var mutation = { type: type, payload: payload };
   if (isObject(type) && type.type) {
+    mutation = type;
     options = payload;
     payload = type;
     type = type.type;
@@ -661,7 +663,7 @@ function unifyObjectStyle (type, payload, options) {
 
   assert(typeof type === 'string', ("Expects string as the type, but found " + (typeof type) + "."));
 
-  return { type: type, payload: payload, options: options }
+  return { type: type, payload: payload, options: options, mutation: mutation }
 }
 
 function install (_Vue) {

--- a/src/store.js
+++ b/src/store.js
@@ -65,10 +65,10 @@ export class Store {
     const {
       type,
       payload,
-      options
+      options,
+      mutation
     } = unifyObjectStyle(_type, _payload, _options)
 
-    const mutation = { type, payload }
     const entry = this._mutations[type]
     if (!entry) {
       console.error(`[vuex] unknown mutation type: ${type}`)
@@ -401,7 +401,9 @@ function getNestedState (state, path) {
 }
 
 function unifyObjectStyle (type, payload, options) {
+  let mutation = { type, payload }
   if (isObject(type) && type.type) {
+    mutation = type
     options = payload
     payload = type
     type = type.type
@@ -409,7 +411,7 @@ function unifyObjectStyle (type, payload, options) {
 
   assert(typeof type === 'string', `Expects string as the type, but found ${typeof type}.`)
 
-  return { type, payload, options }
+  return { type, payload, options, mutation }
 }
 
 export function install (_Vue) {

--- a/test/unit/store.spec.js
+++ b/test/unit/store.spec.js
@@ -37,6 +37,31 @@ describe('Store', () => {
     expect(store.state.a).toBe(3)
   })
 
+  it('should call the subscribers with the committed mutation after committing with object style', () => {
+    const store = new Vuex.Store({
+      state: {
+      },
+      mutations: {
+        [TEST] () {
+        }
+      }
+    })
+
+    let subscriberMutation
+
+    store.subscribe((mutation) => {
+      subscriberMutation = mutation
+    })
+
+    const committedMutation = {
+      type: TEST,
+      amount: 2
+    }
+
+    store.commit(committedMutation)
+    expect(subscriberMutation).toEqual(committedMutation)
+  })
+
   it('asserts committed type', () => {
     const store = new Vuex.Store({
       state: {


### PR DESCRIPTION
After object-style commit subscribers got back the original mutation
wrapped into a new mutation as payload. This was counter-intuitive
and prevented the reuse of mutation objects. For example after the call
commit({ type: 'TEST', amount: 2 }) one would expect to receive the
same object in the subscriber but actually
{ type: 'TEST', payload: { type: 'TEST', amount: 2 } })
was received with the original implementation.