### PR TITLE
Improve module getters definition

### DIFF
--- a/docs/en/api.md
+++ b/docs/en/api.md
@@ -49,12 +49,21 @@ const store = new Vuex.Store({ ...options })
   - type: `{ [key: string]: Function }`
 
     Register getters on the store. The getter function receives the following arguments:
-
+    
     ```
     state,     // will be module local state if defined in a module.
     getters,   // same as store.getters
-    rootState  // same as store.state
     ```
+    
+    Specific when defined in a module
+    
+    ```
+    state,       // will be module local state if defined in a module.
+    getters,     // module local getters of the current module
+    rootState    // global state
+    rootGetters  // all getters
+    ```
+    
     Registered getters are exposed on `store.getters`.
 
     [Details](getters.md)

--- a/docs/en/api.md
+++ b/docs/en/api.md
@@ -49,7 +49,7 @@ const store = new Vuex.Store({ ...options })
   - type: `{ [key: string]: Function }`
 
     Register getters on the store. The getter function receives the following arguments:
-    
+
     ```
     state,     // will be module local state if defined in a module.
     getters,   // same as store.getters


### PR DESCRIPTION
It missing rootGetters for the getters definition in API.