### PR TITLE
Added example of passing payload to mutation with mapMutations helper

### DIFF
--- a/docs/en/mutations.md
+++ b/docs/en/mutations.md
@@ -146,7 +146,10 @@ export default {
   // ...
   methods: {
     ...mapMutations([
-      'increment' // map this.increment() to this.$store.commit('increment')
+      'increment', // map this.increment() to this.$store.commit('increment')
+      
+      // mapMutations also supports payloads:
+      'incrementBy' // this.incrementBy(amount) maps to this.$store.commit('incrementBy', amount)
     ]),
     ...mapMutations({
       add: 'increment' // map this.add() to this.$store.commit('increment')


### PR DESCRIPTION
Added an example of passing a payload to a mutation when using the `mapMutations` helper. This is [included in the documentation on actions](https://github.com/vuejs/vuex/blob/dev/docs/en/actions.md#dispatching-actions-in-components), so thought it would be a good idea to keep the two pages consistent.