### PR TITLE
[DOC] fixes mapState in example

### DIFF
--- a/docs/en/state.md
+++ b/docs/en/state.md
@@ -98,9 +98,9 @@ Note that `mapState` returns an object. How do we use it in combination with oth
 computed: {
   localComputed () { /* ... */ },
   // mix this into the outer object with the object spread operator
-  ...mapState({
+  ...mapState([
     // ...
-  })
+  ])
 }
 ```
 

--- a/docs/fr/state.md
+++ b/docs/fr/state.md
@@ -98,9 +98,9 @@ Notez que `mapState` renvoie un objet. Comment l'utiliser en complément des aut
 computed: {
   localComputed () { /* ... */ },
   // rajouter cet objet dans l'objet `computed` avec l'object spread operator
-  ...mapState({
+  ...mapState([
     // ...
-  })
+  ])
 }
 ```
 

--- a/docs/ja/state.md
+++ b/docs/ja/state.md
@@ -95,9 +95,9 @@ computed: mapState([
 computed: {
   localComputed () { /* ... */ },
   // オブジェクトスプレット演算子で、外のオブジェクトとこのオブジェクトを混ぜる
-  ...mapState({
+  ...mapState([
     // ...
-  })
+  ])
 }
 ```
 

--- a/docs/kr/state.md
+++ b/docs/kr/state.md
@@ -98,9 +98,9 @@ computed: mapState([
 computed: {
   localComputed () { /* ... */ },
   // 이것을 객체 전파 연산자를 사용하여 외부 객체에 추가 하십시오.
-  ...mapState({
+  ...mapState([
     // ...
-  })
+  ])
 }
 ```
 

--- a/docs/ru/state.md
+++ b/docs/ru/state.md
@@ -98,9 +98,9 @@ computed: mapState([
 computed: {
   localComputed () { /* ... */ },
   // результаты работы mapState будут добавлены в уже существующий объект
-  ...mapState({
+  ...mapState([
     // ...
-  })
+  ])
 }
 ```
 

--- a/docs/zh-cn/state.md
+++ b/docs/zh-cn/state.md
@@ -97,9 +97,9 @@ computed: mapState([
 computed: {
   localComputed () { /* ... */ },
   // 使用对象展开运算符将此对象混入到外部对象中
-  ...mapState({
+  ...mapState([
     // ...
-  })
+  ])
 }
 ```
 


### PR DESCRIPTION
Example would currently cause an `Syntax Error: Unexpected token`.

```
  25 |     ...mapState({
  26 |       'story'
> 27 |     })
     |     ^
```

Changed to correct way with array.