### PR TITLE
fix .toggle-all checkbox was hidden

### DIFF
--- a/examples/todomvc/components/App.vue
+++ b/examples/todomvc/components/App.vue
@@ -13,10 +13,11 @@
     </header>
     <!-- main section -->
     <section class="main" v-show="todos.length">
-      <input class="toggle-all"
+      <input class="toggle-all" id="toggle-all"
         type="checkbox"
         :checked="allChecked"
         @change="toggleAll({ done: !allChecked })">
+      <label for="toggle-all"></label>
       <ul class="todo-list">
         <todo v-for="(todo, index) in filteredTodos" :key="index" :todo="todo"></todo>
       </ul>

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "rollup-plugin-replace": "^1.1.1",
     "rollup-watch": "^3.2.2",
     "selenium-server": "^2.53.1",
-    "todomvc-app-css": "^2.0.6",
+    "todomvc-app-css": "^2.1.0",
     "typescript": "^2.1.5",
     "uglify-js": "^2.7.5",
     "vue": "^2.1.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4244,13 +4244,13 @@ selenium-server@^2.53.1:
   version "2.53.1"
   resolved "https://registry.yarnpkg.com/selenium-server/-/selenium-server-2.53.1.tgz#d681528812f3c2e0531a6b7e613e23bb02cce8a6"
 
-"semver@2 || 3 || 4 || 5", semver@~5.0.1:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.0.3.tgz#77466de589cd5d3c95f138aa78bc569a3cb5d27a"
-
-semver@~5.3.0:
+"semver@2 || 3 || 4 || 5", semver@~5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
+
+semver@~5.0.1:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.0.3.tgz#77466de589cd5d3c95f138aa78bc569a3cb5d27a"
 
 send@0.14.2:
   version "0.14.2"
@@ -4609,9 +4609,9 @@ to-fast-properties@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.2.tgz#f3f5c0c3ba7299a7ef99427e44633257ade43320"
 
-todomvc-app-css@^2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/todomvc-app-css/-/todomvc-app-css-2.0.6.tgz#0b3667c5e189f1568d9a9bf7947ebd928406961d"
+todomvc-app-css@^2.1.0:
+  version "2.1.0"
+  resolved "http://registry.npm.taobao.org/todomvc-app-css/download/todomvc-app-css-2.1.0.tgz#b6f2716d339afa2e5f799347d2a48b05396242a5"
 
 tough-cookie@~2.3.0:
   version "2.3.2"


### PR DESCRIPTION
see tastejs/todomvc-app-css#8.

`todomvc-app-css` upgraded version to `2.1.0`, `"todomvc-app-css": "^2.0.6"` in vuex's package.json will download latest version, `.toggle-all` class has a big change, causing it to be hidden in todomvc example.