### PR TITLE
Enable plugins in modules

### DIFF
--- a/src/module/module-collection.js
+++ b/src/module/module-collection.js
@@ -28,14 +28,22 @@ export default class ModuleCollection {
     }, '')
   }
 
+  getParent (path) {
+    return this.get(path.slice(0, -1))
+  }
+
+  getKey (path) {
+    return path[path.length - 1]
+  }
+
   update (rawRootModule) {
     update(this.root, rawRootModule)
   }
 
   register (path, rawModule, runtime = true) {
-    const parent = this.get(path.slice(0, -1))
+    const parent = this.getParent(path)
     const newModule = new Module(rawModule, runtime)
-    parent.addChild(path[path.length - 1], newModule)
+    parent.addChild(this.getKey(path), newModule)
 
     // register nested modules
     if (rawModule.modules) {
@@ -46,8 +54,8 @@ export default class ModuleCollection {
   }
 
   unregister (path) {
-    const parent = this.get(path.slice(0, -1))
-    const key = path[path.length - 1]
+    const parent = this.getParent(path)
+    const key = this.getKey(path)
     if (!parent.getChild(key).runtime) return
 
     parent.removeChild(key)

--- a/src/module/module.js
+++ b/src/module/module.js
@@ -36,6 +36,9 @@ export default class Module {
     if (rawModule.getters) {
       this._rawModule.getters = rawModule.getters
     }
+    if (rawModule.plugins) {
+      this._rawModule.plugins = rawModule.plugins
+    }
   }
 
   forEachChild (fn) {
@@ -57,6 +60,12 @@ export default class Module {
   forEachMutation (fn) {
     if (this._rawModule.mutations) {
       forEachValue(this._rawModule.mutations, fn)
+    }
+  }
+
+  forEachPlugin (fn) {
+    if (this._rawModule.plugins) {
+      forEachValue(this._rawModule.plugins, fn)
     }
   }
 }

--- a/src/store.js
+++ b/src/store.js
@@ -98,11 +98,16 @@ export class Store {
       const re = /.+?\//g
       const matched = namespace.match(re)
       if (matched) {
+        // remove namespace from type
+        const _mutation = {
+          type: type.substring(namespace.length),
+          payload
+        }
         // get parents' subscriptions
         matched.reduce((a, b) => {
           const _namespace = a + b
           const subs = this._modulesSubscribersMap[_namespace]
-          subs && subs.forEach(sub => sub(mutation, this.state))
+          subs && subs.forEach(sub => sub(_mutation, this.state))
           return _namespace
         }, '')
       }

--- a/test/unit/plugins-in-modules.spec.js
+++ b/test/unit/plugins-in-modules.spec.js
@@ -1,0 +1,155 @@
+import Vuex from '../../dist/vuex.js'
+
+const TEST = 'TEST'
+
+describe('Modules', () => {
+  describe('plugins in modules', () => {
+    it('just in root', function () {
+      const mutations = {
+        [TEST] (state, n) {
+          state.a += n
+        }
+      }
+      let total = 0
+      const plugins = [
+        store => store.subscribe(({ payload }, state) => {
+          total += payload
+        })
+      ]
+      const store = new Vuex.Store({
+        state: { a: 1 },
+        mutations,
+        plugins
+      })
+      store.commit(TEST, 1)
+      expect(store.state.a).toBe(2)
+      expect(total).toBe(1)
+    })
+
+    it('always call root subscriptions', function () {
+      const mutations = {
+        [TEST] (state, n) {
+          state.a += n
+        }
+      }
+      let total = 0
+      const plugins = [
+        store => store.subscribe(({ payload }, state) => {
+          total += payload
+        })
+      ]
+      const store = new Vuex.Store({
+        state: { a: 1 },
+        mutations,
+        plugins, // +1 +1
+        modules: {
+          one: {
+            namespaced: true,
+            state: { a: 2 },
+            mutations,
+            plugins // +1
+          }
+        }
+      })
+      store.commit(TEST, 1)
+      // mocking local commit
+      store.commit(`one/${TEST}`, 1, null, 'one/')
+      expect(store.state.a).toBe(2)
+      expect(store.state.one.a).toBe(3)
+      expect(total).toBe(3)
+    })
+
+    it('nested two level', function () {
+      const mutations = {
+        [TEST] (state, n) {
+          state.a += n
+        }
+      }
+      let total = 0
+      const plugins = [
+        store => store.subscribe(({ payload }, state) => {
+          total += payload
+        })
+      ]
+      const store = new Vuex.Store({
+        state: { a: 1 },
+        mutations,
+        plugins, // +1 +1 +1
+        modules: {
+          one: {
+            namespaced: true,
+            state: { a: 2 },
+            mutations,
+            plugins, // +1 +1
+            modules: {
+              two: {
+                namespaced: true,
+                state: { a: 3 },
+                mutations,
+                plugins // +1
+              }
+            }
+          }
+        }
+      })
+      store.commit(TEST, 1)
+      // mocking local commit
+      store.commit(`one/${TEST}`, 1, null, 'one/')
+      store.commit(`one/two/${TEST}`, 1, null, 'one/two/')
+      expect(store.state.a).toBe(2)
+      expect(store.state.one.a).toBe(3)
+      expect(store.state.one.two.a).toBe(4)
+      expect(total).toBe(6)
+    })
+
+    it('nested two level with siblings', function () {
+      const mutations = {
+        [TEST] (state, n) {
+          state.a += n
+        }
+      }
+      let total = 0
+      const plugins = [
+        store => store.subscribe(({ payload }, state) => {
+          total += payload
+        })
+      ]
+      const store = new Vuex.Store({
+        state: { a: 1 },
+        mutations,
+        plugins, // +1 +1 +1 +1
+        modules: {
+          one: {
+            namespaced: true,
+            state: { a: 2 },
+            mutations,
+            plugins, // +1 +1
+            modules: {
+              two: {
+                namespaced: true,
+                state: { a: 3 },
+                mutations,
+                plugins // +1
+              }
+            }
+          },
+          another: {
+            namespaced: true,
+            state: { a: 4 },
+            mutations,
+            plugins // +1
+          }
+        }
+      })
+      store.commit(TEST, 1)
+      // mocking local commit
+      store.commit(`one/${TEST}`, 1, null, 'one/')
+      store.commit(`another/${TEST}`, 1, null, 'another/')
+      store.commit(`one/two/${TEST}`, 1, null, 'one/two/')
+      expect(store.state.a).toBe(2)
+      expect(store.state.one.a).toBe(3)
+      expect(store.state.one.two.a).toBe(4)
+      expect(total).toBe(8)
+    })
+  })
+})


### PR DESCRIPTION
fix: #467.

Plugins in modules now have a localized subscribe.
Mutations in children will fire parents' subscriptions too.