### PR TITLE
Add a try-catch to the testAction helper method example

### DIFF
--- a/docs/en/testing.md
+++ b/docs/en/testing.md
@@ -92,10 +92,16 @@ const testAction = (action, payload, state, expectedMutations, done) => {
   // mock commit
   const commit = (type, payload) => {
     const mutation = expectedMutations[count]
-    expect(mutation.type).to.equal(type)
-    if (payload) {
-      expect(mutation.payload).to.deep.equal(payload)
+    
+    try {
+      expect(mutation.type).to.equal(type)
+      if (payload) {
+        expect(mutation.payload).to.deep.equal(payload)
+      }
+    } catch(error) {
+      done(error)
     }
+    
     count++
     if (count >= expectedMutations.length) {
       done()


### PR DESCRIPTION
When an error occurs in an assertion, you receive the message that your promise hook was not closed within 2 seconds.
By catching the error, we can call done(error) (this works for standard vue-cli template)
1. This makes sure the test is properly closed
2. The assertion error is logged to the console