### PR TITLE
Doc EN `getters.md` : Add new line for consistency

### DIFF
--- a/docs/en/getters.md
+++ b/docs/en/getters.md
@@ -62,6 +62,7 @@ computed: {
 ```
 
 You can also pass arguments to getters by returning a function. This is particularly useful when you want to query an array in the store:
+
 ```js
 getters: {
   // ...

--- a/docs/en/getters.md
+++ b/docs/en/getters.md
@@ -101,7 +101,7 @@ If you want to map a getter to a different name, use an object:
 
 ``` js
 ...mapGetters({
-  // map this.doneCount to store.getters.doneTodosCount
+  // map `this.doneCount` to `store.getters.doneTodosCount`
   doneCount: 'doneTodosCount'
 })
 ```


### PR DESCRIPTION
It's important to kept consistency accross documentation to allows translation to be done number line by number line.

So each new line can be separate by a free line !