### PR TITLE
vuex 支持延迟生成store

### DIFF
--- a/src/mixin.js
+++ b/src/mixin.js
@@ -24,6 +24,9 @@ export default function (Vue) {
     const options = this.$options
     // store injection
     if (options.store) {
+      if (typeof options.store === 'function') {
+        options.store = options.store();
+      }
       this.$store = options.store
     } else if (options.parent && options.parent.$store) {
       this.$store = options.parent.$store

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -25,7 +25,7 @@ export default function (Vue) {
     // store injection
     if (options.store) {
       if (typeof options.store === 'function') {
-        options.store = options.store();
+        options.store = options.store()
       }
       this.$store = options.store
     } else if (options.parent && options.parent.$store) {

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -24,10 +24,9 @@ export default function (Vue) {
     const options = this.$options
     // store injection
     if (options.store) {
-      if (typeof options.store === 'function') {
-        options.store = options.store()
-      }
-      this.$store = options.store
+      this.$store = typeof options.store === 'function'
+        ? options.store()
+        : options.store
     } else if (options.parent && options.parent.$store) {
       this.$store = options.parent.$store
     }


### PR DESCRIPTION
场景：
组件树：(R为根组件；C1为R的子组件；C11、C12为C1的子组件， C11，C12下面还有很多下层组件)
R
|___C1
　　|____C11
　　|____C12
|___C1
　　|____C11
　　|____C12
|___C1
　　|____C11
　　|____C12

C1的每个实例的数据显示是不一样的， 如果使用props传递数据，将会导致所有组件的实例要知道自己的index，不然不知道去修改哪个state。如果vuex支持延时创建store，那么在C1 上面延时生成store，下层组件使用$store的时候，不需要关心当前是哪个store的。