### PR TITLE
feat: add `createNamespacedHelpers()` to help dealing with namespaced modules

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -70,6 +70,13 @@ export const mapActions = normalizeNamespace((namespace, actions) => {
   return res
 })
 
+export const createNamespacedHelpers = (namespace) => ({
+  mapState: mapState.bind(null, namespace),
+  mapGetters: mapGetters.bind(null, namespace),
+  mapMutations: mapMutations.bind(null, namespace),
+  mapActions: mapActions.bind(null, namespace)
+})
+
 function normalizeMap (map) {
   return Array.isArray(map)
     ? map.map(key => ({ key, val: key }))

--- a/src/index.esm.js
+++ b/src/index.esm.js
@@ -1,5 +1,5 @@
 import { Store, install } from './store'
-import { mapState, mapMutations, mapGetters, mapActions } from './helpers'
+import { mapState, mapMutations, mapGetters, mapActions, createNamespacedHelpers } from './helpers'
 
 export default {
   Store,
@@ -8,7 +8,8 @@ export default {
   mapState,
   mapMutations,
   mapGetters,
-  mapActions
+  mapActions,
+  createNamespacedHelpers
 }
 
 export {
@@ -16,5 +17,6 @@ export {
   mapState,
   mapMutations,
   mapGetters,
-  mapActions
+  mapActions,
+  createNamespacedHelpers
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import { Store, install } from './store'
-import { mapState, mapMutations, mapGetters, mapActions } from './helpers'
+import { mapState, mapMutations, mapGetters, mapActions, createNamespacedHelpers } from './helpers'
 
 export default {
   Store,
@@ -8,5 +8,6 @@ export default {
   mapState,
   mapMutations,
   mapGetters,
-  mapActions
+  mapActions,
+  createNamespacedHelpers
 }

--- a/test/unit/helpers.spec.js
+++ b/test/unit/helpers.spec.js
@@ -1,5 +1,5 @@
 import Vue from 'vue/dist/vue.common.js'
-import Vuex, { mapState, mapMutations, mapGetters, mapActions } from '../../dist/vuex.common.js'
+import Vuex, { mapState, mapMutations, mapGetters, mapActions, createNamespacedHelpers } from '../../dist/vuex.common.js'
 
 describe('Helpers', () => {
   it('mapState (array)', () => {
@@ -320,5 +320,62 @@ describe('Helpers', () => {
     expect(b).not.toHaveBeenCalled()
     vm.bar()
     expect(b).toHaveBeenCalled()
+  })
+
+  it('createNamespacedHelpers', () => {
+    const actionA = jasmine.createSpy()
+    const actionB = jasmine.createSpy()
+    const store = new Vuex.Store({
+      modules: {
+        foo: {
+          namespaced: true,
+          state: { count: 0 },
+          getters: {
+            isEven: state => state.count % 2 === 0
+          },
+          mutations: {
+            inc: state => state.count++,
+            dec: state => state.count--
+          },
+          actions: {
+            actionA,
+            actionB
+          }
+        }
+      }
+    })
+    const {
+      mapState,
+      mapGetters,
+      mapMutations,
+      mapActions
+    } = createNamespacedHelpers('foo/')
+    const vm = new Vue({
+      store,
+      computed: {
+        ...mapState(['count']),
+        ...mapGetters(['isEven'])
+      },
+      methods: {
+        ...mapMutations(['inc', 'dec']),
+        ...mapActions(['actionA', 'actionB'])
+      }
+    })
+    expect(vm.count).toBe(0)
+    expect(vm.isEven).toBe(true)
+    store.state.foo.count++
+    expect(vm.count).toBe(1)
+    expect(vm.isEven).toBe(false)
+    vm.inc()
+    expect(store.state.foo.count).toBe(2)
+    expect(store.getters['foo/isEven']).toBe(true)
+    vm.dec()
+    expect(store.state.foo.count).toBe(1)
+    expect(store.getters['foo/isEven']).toBe(false)
+    vm.actionA()
+    expect(actionA).toHaveBeenCalled()
+    expect(actionB).not.toHaveBeenCalled()
+    vm.actionB()
+    expect(actionB).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
When using namespaced Vuex module with Vue components, binding namespace to the helper functions (mapState, mapGetters, mapMutations and mapActions) is a bit verbose. For example:

```js
const storeModule = new Vuex.Store({
  namespaced: true,
  state: { val: 0 },
  actions: {
    someAction() {},
  },
})

const store = new Vuex.Store({
  modules: {
    foo: storeModule,
  },
})

new Vue({
  store,
  state: { str: 'abc' },
  computed: {
    // I split up these two state mapping to take advantage of array syntax
    ...mapState('foo', ['val']),
    ...mapState('foo', {
      newVal(state) {
        return state.val + ' ' + this.str
      },
    })
  },
  methods: {
    ...mapActions('foo', ['someAction']),
    someOtherMethod() {},
  },
})
```

You can see how many times I have repeated to do the binding job to integrate the Vue component with the module assets.

So I wrote a little helper function to help keep the code DRY. You can see the test to learn how that works.