### PR TITLE
Mention how to avoid stateful singletons in SSR (fix #807)

### DIFF
--- a/docs/en/modules.md
+++ b/docs/en/modules.md
@@ -248,7 +248,7 @@ You can also remove a dynamically registered module with `store.unregisterModule
 
 Sometimes we may need to create multiple instances of a module, for example:
 
-- Creating multiple stores that uses the same module;
+- Creating multiple stores that uses the same module (e.g. To [avoid stateful singletons in the SSR](https://ssr.vuejs.org/en/structure.html#avoid-stateful-singletons) when the `runInNewContext` option is `false` or `'once'`);
 - Register the same module multiple times in the same store.
 
 If we use a plain object to declare the state of the module, then that state object will be shared by reference and cause cross store/module state pollution when it's mutated.


### PR DESCRIPTION
Add an example when we want to create multiple stores that uses the same module in the module reuse section. I seem that it is mainly for SSR purpose, isn't it?

Fix #807 