### PR TITLE
dispatcher typescript declaration fix

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -37,8 +37,8 @@ export declare class Store<S> {
 export declare function install(Vue: typeof _Vue): void;
 
 export interface Dispatch {
-  (type: string, payload?: any, options?: DispatchOptions): Promise<any[]>;
-  <P extends Payload>(payloadWithType: P, options?: DispatchOptions): Promise<any[]>;
+  (type: string, payload?: any, options?: DispatchOptions): Promise<any>;
+  <P extends Payload>(payloadWithType: P, options?: DispatchOptions): Promise<any>;
 }
 
 export interface Commit {


### PR DESCRIPTION
With clear JavaScript Vuex.Store I can use logic like this:

```javascript
const myListStore = new Vuex.Store({
    state: {
        list: []
    },
    mutations: {
        addItem: function (state, item) {
            state.list.push(item);
        }
    },
    actions: {
        getItemById: function (action, itemId) {
            return new Promise(function (resolve, reject) {
                for (var i in action.state.list) {
                    if (action.state.list[i].id == itemId) {
                        resolve(action.state.list[i]);
                        return;
                    }
                }
                reject();
            });
        }
    }
});
```

Using TypeScript it will be:

```typescript
const myListStore = new Vuex.Store<MyStateInterface>({
    state: {
        list: []
    },
    mutations: {
        addItem: (state, item: MyItemInterface) => {
            state.list.push(item);
        }
    },
    actions: {
        getItemById: (action, itemId: number) => new Promise<MyItemInterface>((resolve, reject) => {
            for (let i in action.state.list) {
                if (action.state.list[i].id == itemId) {
                    resolve(action.state.list[i]);
                    return;
                }
            }
            reject();
        })
    }
});
```

But I can't use it, because returned promise in Dispatch type uses strict type:

```typescript
export interface Dispatch {
  (type: string, payload?: any, options?: DispatchOptions): Promise<any[]>;
  <P extends Payload>(payloadWithType: P, options?: DispatchOptions): Promise<any[]>;
}
```

Is it possible to change Dispatch type?