### PR TITLE
Proposal: remove usesInit condition

### DIFF
--- a/src/mixin.js
+++ b/src/mixin.js
@@ -2,8 +2,7 @@ export default function (Vue) {
   const version = Number(Vue.version.split('.')[0])
 
   if (version >= 2) {
-    const usesInit = Vue.config._lifecycleHooks.indexOf('init') > -1
-    Vue.mixin(usesInit ? { init: vuexInit } : { beforeCreate: vuexInit })
+    Vue.mixin({ beforeCreate: vuexInit })
   } else {
     // override init and inject vuex init procedure
     // for 1.x backwards compatibility.


### PR DESCRIPTION
- [rename: init -> beforeCreate](https://github.com/vuejs/vue/commit/8c869731988a2bb961955a4c896227977acb4c3d) in v2.0.0-alpha.7
- it's not necessary in the next version