### PR TITLE
Docs: Clarify getter cache behavior

### DIFF
--- a/docs/en/getters.md
+++ b/docs/en/getters.md
@@ -12,7 +12,9 @@ computed: {
 
 If more than one component needs to make use of this, we have to either duplicate the function, or extract it into a shared helper and import it in multiple places - both are less than ideal.
 
-Vuex allows us to define "getters" in the store (think of them as computed properties for stores). Getters will receive the state as their 1st argument:
+Vuex allows us to define "getters" in the store. You can think of them as computed properties for stores. Like computed properties, a getter's result is cached based on its dependencies, and will only re-evaluate when some of its dependencies have changed.
+
+Getters will receive the state as their 1st argument:
 
 ``` js
 const store = new Vuex.Store({


### PR DESCRIPTION
In review getters docs, it was not clear whether the results of a getter were cached. This is alluded to in the remark "think of them as computed properties for stores", and in [reviewing the source](https://github.com/vuejs/vuex/blob/7409d4f6aa36d3de13de96dd7a953ad17ea3575a/src/store.js#L215-L232) it's seen that they are in-fact computed properties under the hood, but I think the docs could benefit from describing this behavior more explicitly. In fact, this alone is a compelling feature of Vuex, as unlike Redux which requires a library like [Reselect](https://github.com/reactjs/reselect) (or my own [Rememo](https://github.com/aduth/rememo)), Vuex has caching built-in to its selector equivalents.