### PR TITLE
Feature: allow same paradigm for lazy loading modules

### DIFF
--- a/docs/en/api.md
+++ b/docs/en/api.md
@@ -158,8 +158,12 @@ const store = new Vuex.Store({ ...options })
 
 - **`registerModule(path: string | Array<string>, module: Module)`**
 
+  **`registerModule(path: string | Array<string>, module: () => Promise<Module>): Promise<void>`**
+
   Register a dynamic module. [Details](modules.md#dynamic-module-registration)
 
+  Lazy load a dynamic module. [Details](modules.md#lazy-load-dynamic-modules)
+  
 - **`unregisterModule(path: string | Array<string>)`**
 
   Unregister a dynamic module. [Details](modules.md#dynamic-module-registration)

--- a/src/store.js
+++ b/src/store.js
@@ -158,10 +158,15 @@ export class Store {
       assert(path.length > 0, 'cannot register the root module by using registerModule.')
     }
 
-    this._modules.register(path, rawModule)
-    installModule(this, this.state, path, this._modules.get(path))
-    // reset store to update getters...
-    resetStoreVM(this, this.state)
+    const moduleResolved = module => {
+      this._modules.register(path, module.default || module)
+      installModule(this, this.state, path, this._modules.get(path))
+      // reset store to update getters...
+      resetStoreVM(this, this.state)
+    }
+
+    if (typeof rawModule === 'function') return rawModule().then(moduleResolved)
+    moduleResolved(rawModule)
   }
 
   unregisterModule (path) {

--- a/test/unit/modules.spec.js
+++ b/test/unit/modules.spec.js
@@ -82,6 +82,36 @@ describe('Modules', () => {
     })
   })
 
+  it('dynamic module registration with promise (dynamic import)', () => {
+    const store = new Vuex.Store({
+      modules: {
+        a: {
+          namespaced: true
+        }
+      }
+    })
+    const actionSpy = jasmine.createSpy()
+    const mutationSpy = jasmine.createSpy()
+    const module = () => Promise.resolve({
+      state: { value: 1 },
+      getters: { foo: state => state.value },
+      actions: { foo: actionSpy },
+      mutations: { foo: mutationSpy }
+    })
+
+    store.registerModule(['a', 'b'], module)
+      .then(() => {
+        expect(store.state.a.b.value).toBe(1)
+        expect(store.getters['a/foo']).toBe(1)
+
+        store.dispatch('a/foo')
+        expect(actionSpy).toHaveBeenCalled()
+
+        store.commit('a/foo')
+        expect(mutationSpy).toHaveBeenCalled()
+      })
+  })
+
   // #524
   it('should not fire an unrelated watcher', done => {
     const spy = jasmine.createSpy()

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -20,6 +20,8 @@ export declare class Store<S> {
   subscribe<P extends Payload>(fn: (mutation: P, state: S) => any): () => void;
   watch<T>(getter: (state: S) => T, cb: (value: T, oldValue: T) => void, options?: WatchOptions): void;
 
+  registerModule<T>(path: string, module: () => Promise<Module<T, S>>): Promise<void>;
+  registerModule<T>(path: string[], module: () => Promise<Module<T, S>>): Promise<void>;
   registerModule<T>(path: string, module: Module<T, S>): void;
   registerModule<T>(path: string[], module: Module<T, S>): void;
 

--- a/types/test/index.ts
+++ b/types/test/index.ts
@@ -199,6 +199,11 @@ namespace RegisterModule {
     state: { value: 2 }
   });
 
+  const asyncModule = () => Promise.resolve({ state: { value: 1 }})
+  store.registerModule("a", asyncModule)
+    .then(() => {})
+    .catch(error => {})
+
   store.unregisterModule(["a", "b"]);
   store.unregisterModule("a");
 }


### PR DESCRIPTION
As described in https://github.com/vuejs/vuex/pull/837

This will keep the same paradigm in Vuex as rest of ecosystem for dynamically loading store modules:

`store.registerModule('a', () => import('@/store/modules/a'))`

