### PR TITLE
Remove `src` directory from npm module

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "typings": "types/index.d.ts",
   "files": [
     "dist",
-    "src",
     "types/index.d.ts",
     "types/helpers.d.ts",
     "types/vue.d.ts"


### PR DESCRIPTION
Continue reducing vue modules size, started in https://github.com/vuejs/vue/pull/6072. Removing `src` directory reduces size of installed `vuex` package by 33% (96kb instead of 144kb)