### PR TITLE
Add MutationPayload type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -17,7 +17,7 @@ export declare class Store<S> {
   dispatch: Dispatch;
   commit: Commit;
 
-  subscribe<P extends Payload>(fn: (mutation: P, state: S) => any): () => void;
+  subscribe<P extends MutationPayload>(fn: (mutation: P, state: S) => any): () => void;
   watch<T>(getter: (state: S) => T, cb: (value: T, oldValue: T) => void, options?: WatchOptions): void;
 
   registerModule<T>(path: string, module: Module<T, S>): void;
@@ -57,6 +57,10 @@ export interface ActionContext<S, R> {
 
 export interface Payload {
   type: string;
+}
+
+export interface MutationPayload extends Payload {
+  payload: any;
 }
 
 export interface DispatchOptions {

--- a/types/test/index.ts
+++ b/types/test/index.ts
@@ -35,6 +35,7 @@ namespace StoreInstance {
 
   store.subscribe((mutation, state) => {
     mutation.type;
+    mutation.payload;
     state.value;
   });
 


### PR DESCRIPTION
On the subscribe function, the mutation object was only having the `type` property and missing the payload