### PR TITLE
feat(store): bind mutation and action handlers to store

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -373,14 +373,14 @@ function makeLocalGetters (store, namespace) {
 function registerMutation (store, type, handler, local) {
   const entry = store._mutations[type] || (store._mutations[type] = [])
   entry.push(function wrappedMutationHandler (payload) {
-    handler(local.state, payload)
+    handler.call(store, local.state, payload)
   })
 }
 
 function registerAction (store, type, handler, local) {
   const entry = store._actions[type] || (store._actions[type] = [])
   entry.push(function wrappedActionHandler (payload, cb) {
-    let res = handler({
+    let res = handler.call(store, {
       dispatch: local.dispatch,
       commit: local.commit,
       getters: local.getters,


### PR DESCRIPTION
- [x] Feature
- [x] Not affecting current API

As of vue's `runInNewContext` enhancement for SSR, everything should be stateless in server side to prevent each request affecting others so when implementing Actions which need access to `ssrContext` (Like axios with configured proper auth headers - nuxt-community/modules#26) the only way is passing those references from caller as action/mutation parameters ([example](https://github.com/nuxt-community/modules/tree/master/modules/axios#store-actions)), this is working but makes usage ugly and really harder. This enhancement is required for workaround and fixes by simply binding handlers to store instance. So we can inject state into store and access it using `this` inside action/mutation functions. (`this` is currently undefined inside handlers)