### PR TITLE
perf: do not connect devtools if Vue.config.devtools == false

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -58,7 +58,11 @@ export class Store {
     resetStoreVM(this, state)
 
     // apply plugins
-    plugins.concat(devtoolPlugin).forEach(plugin => plugin(this))
+    plugins.forEach(plugin => plugin(this))
+
+    if (Vue.config.devtools) {
+      devtoolPlugin(this)
+    }
   }
 
   get state () {


### PR DESCRIPTION
Vuex always connects vue-devtools currently but it would not make sense if devtools is disabled via Vue's config.

This PR let devtoolPlugin be disable if `Vue.config.devtools === false`

Fix #875 