### PR TITLE
Add a testcase for mapGetters (with namespace and nested module)

### DIFF
--- a/test/unit/helpers.spec.js
+++ b/test/unit/helpers.spec.js
@@ -251,6 +251,59 @@ describe('Helpers', () => {
     expect(vm.b).toBe(true)
   })
 
+  it('mapGetters (with namespace and nested module)', () => {
+    const store = new Vuex.Store({
+      modules: {
+        foo: {
+          namespaced: true,
+          modules: {
+            bar: {
+              namespaced: true,
+              state: { count: 0 },
+              mutations: {
+                inc: state => state.count++,
+                dec: state => state.count--
+              },
+              getters: {
+                hasAny: ({ count }) => count > 0,
+                negative: ({ count }) => count < 0
+              }
+            },
+            cat: {
+              state: { count: 9 },
+              getters: {
+                count: ({ count }) => count
+              }
+            }
+          }
+        }
+      }
+    })
+    const vm = new Vue({
+      store,
+      computed: {
+        ...mapGetters('foo/bar', [
+          'hasAny',
+          'negative'
+        ]),
+        ...mapGetters('foo', [
+          'count'
+        ])
+      }
+    })
+    expect(vm.hasAny).toBe(false)
+    expect(vm.negative).toBe(false)
+    store.commit('foo/bar/inc')
+    expect(vm.hasAny).toBe(true)
+    expect(vm.negative).toBe(false)
+    store.commit('foo/bar/dec')
+    store.commit('foo/bar/dec')
+    expect(vm.hasAny).toBe(false)
+    expect(vm.negative).toBe(true)
+
+    expect(vm.count).toBe(9)
+  })
+
   it('mapActions (array)', () => {
     const a = jasmine.createSpy()
     const b = jasmine.createSpy()


### PR DESCRIPTION
因為一直 [vuex] module namespace not found in mapGetters() 找不到原因是為啥。

去看測試，發現沒有 nested 的測試案例，就寫了個。

寫完跑完發現會過... 原來是我代碼太多層有一層忘了加 namespaced: true...
