### PR TITLE
fix: move auto installation code into the store constructor

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -7,6 +7,13 @@ let Vue // bind on install
 
 export class Store {
   constructor (options = {}) {
+    // Auto install if it is not done yet and `window` has `Vue`.
+    // To allow users to avoid auto-installation in some cases,
+    // this code should be placed here. See #731
+    if (!Vue && typeof window !== 'undefined' && window.Vue) {
+      install(window.Vue)
+    }
+
     if (process.env.NODE_ENV !== 'production') {
       assert(Vue, `must call Vue.use(Vuex) before creating a store instance.`)
       assert(typeof Promise !== 'undefined', `vuex requires a Promise polyfill in this browser.`)
@@ -462,9 +469,4 @@ export function install (_Vue) {
   }
   Vue = _Vue
   applyMixin(Vue)
-}
-
-// auto install in dist mode
-if (typeof window !== 'undefined' && window.Vue) {
-  install(window.Vue)
 }


### PR DESCRIPTION
While auto-calling `Vue.use(Vuex)` is convenient for users who use Vue/Vuex via `<script>`, there are a case that users want to avoid the behavior when `window.Vue` is exists (See #731).

Currently, Vuex is immediately installed into `window.Vue` when Vuex is imported. So there are no way to install Vuex into `import`ed Vue.

To solve this, I'd move it in `Vuex.Store`'s constructor. Then the auto-installation is delayed until users create a store and the users can install Vuex into their own Vue constructor before doing it.

I'm not sure how to write test code for this but it looks like working well.

fix #731 