### PR TITLE
Update api.md: take createNamespacedHelpers out

### DIFF
--- a/docs/en/api.md
+++ b/docs/en/api.md
@@ -193,7 +193,3 @@ const store = new Vuex.Store({ ...options })
   Create component methods options that commit a mutation. [Details](mutations.md#commiting-mutations-in-components)
 
   The first argument can optionally be a namespace string. [Details](modules.md#binding-helpers-with-namespace)
-
-- **`createNamespacedHelpers(namespace: string): Object`**
-
-  Create namespaced component binding helpers. The returned object contains `mapState`, `mapGetters`, `mapActions` and `mapMutations` that are bound with the given namespace. [Details](modules.md#binding-helpers-with-namespace)


### PR DESCRIPTION
createNamespacedHelpers seems to not belong to 'vuex' package