### PR TITLE
feat: allow to passing functions in mapActions/mapMutations (fix #750)

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -25,12 +25,18 @@ export const mapState = normalizeNamespace((namespace, states) => {
 export const mapMutations = normalizeNamespace((namespace, mutations) => {
   const res = {}
   normalizeMap(mutations).forEach(({ key, val }) => {
-    val = namespace + val
     res[key] = function mappedMutation (...args) {
-      if (namespace && !getModuleByNamespace(this.$store, 'mapMutations', namespace)) {
-        return
+      let commit = this.$store.commit
+      if (namespace) {
+        const module = getModuleByNamespace(this.$store, 'mapMutations', namespace)
+        if (!module) {
+          return
+        }
+        commit = module.context.commit
       }
-      return this.$store.commit.apply(this.$store, [val].concat(args))
+      return typeof val === 'function'
+        ? val.apply(this, [commit].concat(args))
+        : commit.apply(this.$store, [val].concat(args))
     }
   })
   return res
@@ -59,12 +65,18 @@ export const mapGetters = normalizeNamespace((namespace, getters) => {
 export const mapActions = normalizeNamespace((namespace, actions) => {
   const res = {}
   normalizeMap(actions).forEach(({ key, val }) => {
-    val = namespace + val
     res[key] = function mappedAction (...args) {
-      if (namespace && !getModuleByNamespace(this.$store, 'mapActions', namespace)) {
-        return
+      let dispatch = this.$store.dispatch
+      if (namespace) {
+        const module = getModuleByNamespace(this.$store, 'mapActions', namespace)
+        if (!module) {
+          return
+        }
+        dispatch = module.context.dispatch
       }
-      return this.$store.dispatch.apply(this.$store, [val].concat(args))
+      return typeof val === 'function'
+        ? val.apply(this, [dispatch].concat(args))
+        : dispatch.apply(this.$store, [val].concat(args))
     }
   })
   return res

--- a/test/unit/helpers.spec.js
+++ b/test/unit/helpers.spec.js
@@ -133,6 +133,27 @@ describe('Helpers', () => {
     expect(store.state.count).toBe(0)
   })
 
+  it('mapMutations (function)', () => {
+    const store = new Vuex.Store({
+      state: { count: 0 },
+      mutations: {
+        inc (state, amount) {
+          state.count += amount
+        }
+      }
+    })
+    const vm = new Vue({
+      store,
+      methods: mapMutations({
+        plus (commit, amount) {
+          commit('inc', amount + 1)
+        }
+      })
+    })
+    vm.plus(42)
+    expect(store.state.count).toBe(43)
+  })
+
   it('mapMutations (with namespace)', () => {
     const store = new Vuex.Store({
       modules: {
@@ -157,6 +178,32 @@ describe('Helpers', () => {
     expect(store.state.foo.count).toBe(1)
     vm.minus()
     expect(store.state.foo.count).toBe(0)
+  })
+
+  it('mapMutations (function with namepsace)', () => {
+    const store = new Vuex.Store({
+      modules: {
+        foo: {
+          namespaced: true,
+          state: { count: 0 },
+          mutations: {
+            inc (state, amount) {
+              state.count += amount
+            }
+          }
+        }
+      }
+    })
+    const vm = new Vue({
+      store,
+      methods: mapMutations('foo', {
+        plus (commit, amount) {
+          commit('inc', amount + 1)
+        }
+      })
+    })
+    vm.plus(42)
+    expect(store.state.foo.count).toBe(43)
   })
 
   it('mapGetters (array)', () => {
@@ -347,6 +394,23 @@ describe('Helpers', () => {
     expect(b).toHaveBeenCalled()
   })
 
+  it('mapActions (function)', () => {
+    const a = jasmine.createSpy()
+    const store = new Vuex.Store({
+      actions: { a }
+    })
+    const vm = new Vue({
+      store,
+      methods: mapActions({
+        foo (dispatch, arg) {
+          dispatch('a', arg + 'bar')
+        }
+      })
+    })
+    vm.foo('foo')
+    expect(a.calls.argsFor(0)[1]).toBe('foobar')
+  })
+
   it('mapActions (with namespace)', () => {
     const a = jasmine.createSpy()
     const b = jasmine.createSpy()
@@ -373,6 +437,28 @@ describe('Helpers', () => {
     expect(b).not.toHaveBeenCalled()
     vm.bar()
     expect(b).toHaveBeenCalled()
+  })
+
+  it('mapActions (function with namespace)', () => {
+    const a = jasmine.createSpy()
+    const store = new Vuex.Store({
+      modules: {
+        foo: {
+          namespaced: true,
+          actions: { a }
+        }
+      }
+    })
+    const vm = new Vue({
+      store,
+      methods: mapActions('foo/', {
+        foo (dispatch, arg) {
+          dispatch('a', arg + 'bar')
+        }
+      })
+    })
+    vm.foo('foo')
+    expect(a.calls.argsFor(0)[1]).toBe('foobar')
   })
 
   it('createNamespacedHelpers', () => {

--- a/types/helpers.d.ts
+++ b/types/helpers.d.ts
@@ -1,4 +1,5 @@
 import Vue = require("vue");
+import { Dispatch, Commit } from './index';
 
 type Dictionary<T> = { [key: string]: T };
 type Computed = () => any;
@@ -13,6 +14,17 @@ interface Mapper<R> {
 interface MapperWithNamespace<R> {
   (namespace: string, map: string[]): Dictionary<R>;
   (namespace: string, map: Dictionary<string>): Dictionary<R>;
+}
+
+interface FunctionMapper<F, R> {
+  (map: Dictionary<(this: typeof Vue, fn: F, ...args: any[]) => any>): Dictionary<R>;
+}
+
+interface FunctionMapperWithNamespace<F, R> {
+  (
+    namespace: string,
+    map: Dictionary<(this: typeof Vue, fn: F, ...args: any[]) => any>
+  ): Dictionary<R>;
 }
 
 interface MapperForState {
@@ -30,9 +42,9 @@ interface MapperForStateWithNamespace {
 
 interface NamespacedMappers {
   mapState: Mapper<Computed> & MapperForState;
-  mapMutations: Mapper<MutationMethod>;
+  mapMutations: Mapper<MutationMethod> & FunctionMapper<Commit, MutationMethod>;
   mapGetters: Mapper<Computed>;
-  mapActions: Mapper<ActionMethod>;
+  mapActions: Mapper<ActionMethod> & FunctionMapper<Dispatch, ActionMethod>;
 }
 
 export declare const mapState: Mapper<Computed>
@@ -41,12 +53,16 @@ export declare const mapState: Mapper<Computed>
   & MapperForStateWithNamespace;
 
 export declare const mapMutations: Mapper<MutationMethod>
-  & MapperWithNamespace<MutationMethod>;
+  & MapperWithNamespace<MutationMethod>
+  & FunctionMapper<Commit, MutationMethod>
+  & FunctionMapperWithNamespace<Commit, MutationMethod>;
 
 export declare const mapGetters: Mapper<Computed>
   & MapperWithNamespace<Computed>;
 
 export declare const mapActions: Mapper<ActionMethod>
-  & MapperWithNamespace<ActionMethod>;
+  & MapperWithNamespace<ActionMethod>
+  & FunctionMapper<Dispatch, ActionMethod>
+  & FunctionMapperWithNamespace<Dispatch, ActionMethod>;
 
 export declare function createNamespacedHelpers(namespace: string): NamespacedMappers;

--- a/types/test/helpers.ts
+++ b/types/test/helpers.ts
@@ -61,28 +61,82 @@ new Vue({
     mapActions({
       h: "h"
     }),
+    mapActions({
+      g (dispatch, a: string, b: number, c: boolean): void {
+        dispatch('g', { a, b, c })
+        dispatch({
+          type: 'g',
+          a,
+          b,
+          c
+        })
+      }
+    }),
     mapActions('foo', ["g"]),
     mapActions('foo', {
       h: "h"
+    }),
+    mapActions('foo', {
+      g (dispatch, a: string, b: number, c: boolean): void {
+        dispatch('g', { a, b, c })
+        dispatch({
+          type: 'g',
+          a,
+          b,
+          c
+        })
+      }
     }),
 
     mapMutations(["i"]),
     mapMutations({
       j: "j"
     }),
+    mapMutations({
+      i (commit, a: string, b: number, c: boolean): void {
+        commit('i', { a, b, c })
+        commit({
+          type: 'i',
+          a,
+          b,
+          c
+        })
+      }
+    }),
     mapMutations('foo', ["i"]),
     mapMutations('foo', {
       j: "j"
+    }),
+    mapMutations('foo', {
+      i (commit, a: string, b: number, c: boolean): void {
+        commit('i', { a, b, c })
+        commit({
+          type: 'i',
+          a,
+          b,
+          c
+        })
+      }
     }),
 
     helpers.mapActions(["m"]),
     helpers.mapActions({
       m: "m"
     }),
+    helpers.mapActions({
+      m (dispatch, value: string) {
+        dispatch('m', value)
+      }
+    }),
 
     helpers.mapMutations(["n"]),
     helpers.mapMutations({
       n: "n"
+    }),
+    helpers.mapMutations({
+      n (commit, value: string) {
+        commit('m', value)
+      }
     }),
 
     {


### PR DESCRIPTION
This is a small improvement for `mapActions` and `mapMutations` helpers. It allows users to pass functions in the helpers so that reducing some redundant method definitions. The feature is like a counterpart of passing function in `mapState`.

For example:

```js
const vm = new Vue({
  store,
  template: `<input @input="onInput">`
  methods: mapActions({
    onInput (dispatch, event) {
      // First argument is as same as this.$store.dispatch
      dispatch('inputText', {
        text: event.value
      })
    }
  })
})
```

The above code is equivalent with the below (Note that `inputText` is a bit redundant since it is just an bridge method between `onInput` and the action):

```js
const vm = new Vue({
  store,
  template: `<input @input="onInput">`
  methods: {
    ...mapActions(['inputText']),
    onInput (event) {
      this.inputText({
        text: event.value
      })
    }
  })
})
```

In addition, this syntax is more effective when we map namespaced modules.

```js
methods: mapActions('some/module', {
  onInput (dispatch, event) {
    // `dispatch` is already namespaced here.
    // So the below line will call `some/module/inputText` action.
    dispatch('inputText', {
      text: event.value
    })
  }
})
```

I did not implement this syntax for `mapGetters` because we already can do the same thing with `mapState`.

Close #750