### PR TITLE
fix: initialize root state as an empty object if state function returns no value

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -24,7 +24,7 @@ export class Store {
     if (typeof state === 'function') {
       state = state()
     }
-    
+
     if (process.env.NODE_ENV !== 'production') {
       assert(state != null, `State must be an object.`)
     }

--- a/src/store.js
+++ b/src/store.js
@@ -24,6 +24,10 @@ export class Store {
     if (typeof state === 'function') {
       state = state()
     }
+    
+    if (process.env.NODE_ENV !== 'production') {
+      assert(state != null, `State must be an object.`)
+    }
 
     // store internal state
     this._committing = false

--- a/src/store.js
+++ b/src/store.js
@@ -22,11 +22,7 @@ export class Store {
       state = {}
     } = options
     if (typeof state === 'function') {
-      state = state()
-    }
-
-    if (process.env.NODE_ENV !== 'production') {
-      assert(state != null, `State must be an object.`)
+      state = state() || {}
     }
 
     // store internal state


### PR DESCRIPTION
Just a moment ago I had hard time debugging this code:
```js
const state = () => {}
...
new Vuex.Store({
    state,
    modules,
    ...
})
```
If state is `undefined` and you use modules, Vuex can't create store. This small change will make it easier to find this error.