### PR TITLE
Proposal: Global action enhancers - WIP

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -64,3 +64,26 @@ export function isPromise (val) {
 export function assert (condition, msg) {
   if (!condition) throw new Error(`[vuex] ${msg}`)
 }
+
+/**
+ * Taken from Redux repo
+ * Composes single-argument functions from right to left. The rightmost
+ * function can take multiple arguments as it provides the signature for
+ * the resulting composite function.
+ *
+ * @param {...Function} funcs The functions to compose.
+ * @returns {Function} A function obtained by composing the argument functions
+ * from right to left. For example, compose(f, g, h) is identical to doing
+ * (...args) => f(g(h(...args))).
+ */
+export function compose (...funcs) {
+  if (funcs.length === 0) {
+    return arg => arg
+  }
+
+  if (funcs.length === 1) {
+    return funcs[0]
+  }
+
+  return funcs.reduce((a, b) => (...args) => a(b(...args)))
+}


### PR DESCRIPTION
Proposal to bring Global action enhancers.

I wanted a way to log all actions and their payload when dispatched. Following the discussion in https://github.com/vuejs/vuex/issues/908 seems like there is no way right now to do cleanly.

The proposal is to bring global action enhancers that work just like redux's middleware.

Using the count example and some inline actionEnhancers:

```js
export default new Vuex.Store({
  state,
  getters,
  actions,
  mutations,
  actionEnhancers: [
    context => next => (action, payload) => {
      console.log('Hello from first enhancer:', context.state.count)
      return next(action, payload)
    },
    context => next => (action, payload) => {
      console.log('Hello from second enhancer:', context.state.count)
      return next(action, payload)
    }
  ]
})
```

If we can get something like this, then adding an actions tab in devtools would be pretty straight forward.

TODO:
- Feedback
- Docs
- Tests