### PR TITLE
feat: subscribeAction

### DIFF
--- a/test/unit/modules.spec.js
+++ b/test/unit/modules.spec.js
@@ -553,7 +553,9 @@ describe('Modules', () => {
 
     it('plugins', function () {
       let initState
+      const actionSpy = jasmine.createSpy()
       const mutations = []
+      const subscribeActionSpy = jasmine.createSpy()
       const store = new Vuex.Store({
         state: {
           a: 1
@@ -563,21 +565,31 @@ describe('Modules', () => {
             state.a += n
           }
         },
+        actions: {
+          [TEST]: actionSpy
+        },
         plugins: [
           store => {
             initState = store.state
             store.subscribe((mut, state) => {
-              expect(state).toBe(store.state)
+              expect(state).toBe(state)
               mutations.push(mut)
             })
+            store.subscribeAction(subscribeActionSpy)
           }
         ]
       })
       expect(initState).toBe(store.state)
       store.commit(TEST, 2)
+      store.dispatch(TEST, 2)
       expect(mutations.length).toBe(1)
       expect(mutations[0].type).toBe(TEST)
       expect(mutations[0].payload).toBe(2)
+      expect(actionSpy).toHaveBeenCalled()
+      expect(subscribeActionSpy).toHaveBeenCalledWith(
+        { type: TEST, payload: 2 },
+        store.state
+      )
     })
   })
 

--- a/test/unit/store.spec.js
+++ b/test/unit/store.spec.js
@@ -286,6 +286,32 @@ describe('Store', () => {
     expect(store.state.a).toBe(3)
   })
 
+  it('subscribe: should handle subscriptions / unsubscriptions', () => {
+    const subscribeSpy = jasmine.createSpy()
+    const secondSubscribeSpy = jasmine.createSpy()
+    const testPayload = 2
+    const store = new Vuex.Store({
+      state: {},
+      mutations: {
+        [TEST]: () => {}
+      }
+    })
+
+    const unsubscribe = store.subscribe(subscribeSpy)
+    store.subscribe(secondSubscribeSpy)
+    store.commit(TEST, testPayload)
+    unsubscribe()
+    store.commit(TEST, testPayload)
+
+    expect(subscribeSpy).toHaveBeenCalledWith(
+      { type: TEST, payload: testPayload },
+      store.state
+    )
+    expect(secondSubscribeSpy).toHaveBeenCalled()
+    expect(subscribeSpy.calls.count()).toBe(1)
+    expect(secondSubscribeSpy.calls.count()).toBe(2)
+  })
+
   // store.watch should only be asserted in non-SSR environment
   if (!isSSR) {
     it('strict mode: warn mutations outside of handlers', () => {


### PR DESCRIPTION
Allows to listen dispatched actions

After feedback from https://github.com/vuejs/vuex/pull/929 so we can implement #908

API is as suggested by @ktsn 
```js
function actionLoggerPlugin(store) {
  store.subscribeAction(({ type, payload }, state) => {
    console.log(`Before dispatching "${type}" with ${JSON.stringify(payload)}`
  })
}

const store = new Vuex.Store({
  // ...
  plugins: [actionLoggerPlugin]
})
```