### PR TITLE
inject-loader 예약어 수정

### DIFF
--- a/docs/kr/testing.md
+++ b/docs/kr/testing.md
@@ -72,7 +72,7 @@ export const getAllProducts = ({ commit }) => {
 // inject-loader를 사용하면 조작된 의존성을
 // 주입 할 수있는 모듈 팩토리가 반환됩니다.
 import { expect } from 'chai'
-const actionsInjector = require('inject!./actions')
+const actionsInjector = require('inject-loader!./actions')
 
 // 조작된 모의 응답과 함께 모듈 생성
 const actions = actionsInjector({


### PR DESCRIPTION
actionsInjector 를 불러올 때 inject-loader의 inject 예약어는 더이상 지원하지 않는다고 하네요.
require('inject!./actions')   >>  require('inject-loader!./actions')