### PR TITLE
Proposal: createLogger can optionally log actions

### DIFF
--- a/dist/logger.d.ts
+++ b/dist/logger.d.ts
@@ -10,6 +10,10 @@ export interface LoggerOption<S> {
   filter?: <P extends Payload>(mutation: P, stateBefore: S, stateAfter: S) => boolean;
   transformer?: (state: S) => any;
   mutationTransformer?: <P extends Payload>(mutation: P) => any;
+  actionFilter?: <P extends Payload>(action: P, state: S) => boolean;
+  actionTransformer?: <P extends Payload>(action: P) => any;
+  logActions?: boolean;
+  logMutations?: boolean;
 }
 
 export default function createLogger<S>(option?: LoggerOption<S>): Plugin<S>;

--- a/docs/guide/plugins.md
+++ b/docs/guide/plugins.md
@@ -128,7 +128,7 @@ const logger = createLogger({
     // Same as mutationTransformer but for actions
     return action.type
   },
-  logActions: false, // Log Actions
+  logActions: true, // Log Actions
   logMutations: true, // Log mutations
   logger: console, // implementation of the `console` API, default `console`
 })

--- a/docs/guide/plugins.md
+++ b/docs/guide/plugins.md
@@ -109,6 +109,11 @@ const logger = createLogger({
     // `mutation` is a `{ type, payload }`
     return mutation.type !== "aBlacklistedMutation"
   },
+  actionFilter (action, state) {
+    // same as `filter` but for actions
+    // `action` is a `{ type, payload }`
+    return action.type !== "aBlacklistedAction"
+  },
   transformer (state) {
     // transform the state before logging it.
     // for example return only a specific sub-tree
@@ -119,6 +124,12 @@ const logger = createLogger({
     // we can format it any way we want.
     return mutation.type
   },
+  actionTransformer (action) {
+    // Same as mutationTransformer but for actions
+    return action.type
+  },
+  logActions: false, // Log Actions
+  logMutations: true, // Log mutations
   logger: console, // implementation of the `console` API, default `console`
 })
 ```

--- a/src/plugins/devtool.js
+++ b/src/plugins/devtool.js
@@ -19,4 +19,8 @@ export default function devtoolPlugin (store) {
   store.subscribe((mutation, state) => {
     devtoolHook.emit('vuex:mutation', mutation, state)
   })
+
+  store.subscribeAction((action, state) => {
+    devtoolHook.emit('vuex:action', action, state)
+  })
 }

--- a/src/plugins/logger.js
+++ b/src/plugins/logger.js
@@ -9,7 +9,7 @@ export default function createLogger ({
   mutationTransformer = mut => mut,
   actionFilter = (action, state) => true,
   actionTransformer = act => act,
-  logActions = false,
+  logActions = true,
   logMutations = true,
   logger = console
 } = {}) {
@@ -42,9 +42,7 @@ export default function createLogger ({
 
     if (logActions) {
       store.subscribeAction((action, state) => {
-        const currentState = deepCopy(state)
-
-        if (actionFilter(action, currentState)) {
+        if (actionFilter(action, state)) {
           const formattedTime = getFormattedTime()
           const formattedAction = actionTransformer(action)
           const message = `action ${action.type}${formattedTime}`


### PR DESCRIPTION
## Proposal
Allow `createLogger` to optionally log actions, added a couple of options
```js
{
  actionFilter,
  actionTransformer,
  logActions,
  logMutations
}
```

~With some sane default to keep current functionality by default, this would be an opt-in option.~ Enabled by default as requested.

When enabled you get something like:
![](https://user-images.githubusercontent.com/2752665/30676356-4db7bc52-9e4b-11e7-847c-99c189f1c270.png)

It just logs the action type and payload, since we cant tie actions to mutations, which I think its ok.

Note: Also added the `devtoolHook` for actions so we can hook it up later with devtools.

PS: I'm about to do a small plugin in case this proposal doesn't get approved and will update this PR with the url just in case someone is looking for this functionality. It would be awesome if we could have it built-in tho.