### PR TITLE
update docs of state & mutation & action

### DIFF
--- a/docs/en/actions.md
+++ b/docs/en/actions.md
@@ -129,7 +129,7 @@ export default {
   methods: {
     ...mapActions({
       addAlias: function (dispatch) {
-        dispatch('increment') // map `this.addAlias(amount)` to `this.$store.dispatch('increment', amount)`
+        dispatch('increment') // map `this.addAlias()` to `this.$store.dispatch('increment')`
       }
     })
   }
@@ -155,7 +155,7 @@ export default {
     }),
     ...mapActions('moduleName', {
       addAlias: function (dispatch) {
-        dispatch('increment') // map `this.addAlias(amount)` to `this.$store.dispatch('increment', amount)`
+        dispatch('increment') // map `this.addAlias()` to `this.$store.dispatch('increment')`
       }
     })
   }

--- a/docs/en/actions.md
+++ b/docs/en/actions.md
@@ -119,6 +119,49 @@ export default {
 }
 ```
 
+You can also use the mapActions helper to map component methods like this:
+
+``` js
+import { mapActions } from 'vuex'
+
+export default {
+  // ...
+  methods: {
+    ...mapActions({
+      addAlias: function (dispatch) {
+        dispatch('increment') // map `this.addAlias(amount)` to `this.$store.dispatch('increment', amount)`
+      }
+    })
+  }
+}
+```
+
+mapActions can also receive a module name as the first argument so as to commit action to a module with namespace:
+
+``` js
+import { mapActions } from 'vuex'
+
+export default {
+  // ...
+  methods: {
+    ...mapActions('moduleName', [
+      'increment', // map `this.increment()` to `this.$store.dispatch('increment')`
+
+      // `mapActions` 也支持载荷：
+      'incrementBy' // map `this.incrementBy(amount)` to `this.$store.dispatch('incrementBy', amount)`
+    ]),
+    ...mapActions('moduleName', {
+      add: 'increment' // map `this.add()` to `this.$store.dispatch('increment')`
+    }),
+    ...mapActions('moduleName', {
+      addAlias: function (dispatch) {
+        dispatch('increment') // map `this.addAlias(amount)` to `this.$store.dispatch('increment', amount)`
+      }
+    })
+  }
+}
+```
+
 ### Composing Actions
 
 Actions are often asynchronous, so how do we know when an action is done? And more importantly, how can we compose multiple actions together to handle more complex async flows?

--- a/docs/en/mutations.md
+++ b/docs/en/mutations.md
@@ -158,7 +158,7 @@ export default {
   }
 }
 ```
-You can also use the `mapMutations` helper to maps component methods like this:
+You can also use the `mapMutations` helper to map component methods like this:
 
 ``` js
 import { mapMutations } from 'vuex'

--- a/docs/en/mutations.md
+++ b/docs/en/mutations.md
@@ -158,6 +158,47 @@ export default {
   }
 }
 ```
+You can also use the `mapMutations` helper to maps component methods like this:
+
+``` js
+import { mapMutations } from 'vuex'
+
+export default {
+  // ...
+  methods: {
+    ...mapMutations({
+      addAlias: function(commit) {
+          commit('increment') //map `this.addAlias(amount)` to `this.$store.commit('increment', amount)`
+      }
+    })
+  }
+}
+```
+mapMutations can also receive a module name as the first argument so as to commit mutattion to a module with namespace:
+
+``` js
+import { mapMutations } from 'vuex'
+
+export default {
+  // ...
+  methods: {
+    ...mapMutations('moduleName', [
+      'increment', // map `this.increment()` to `this.$store.commit('increment')`
+
+      // `mapMutations` also supports payloads:
+      'incrementBy' // map `this.incrementBy(amount)` to `this.$store.commit('incrementBy', amount)`
+    ]),
+    ...mapMutations('moduleName', {
+      add: 'increment' // map `this.add()` to `this.$store.commit('increment')`
+    }),
+    ...mapMutations('moduleName', {
+      addAlias: function(commit) {
+          commit('increment') //map `this.addAlias(amount)` to `this.$store.commit('increment', amount)`
+      }
+    })
+  }
+}
+```
 
 ### On to Actions
 

--- a/docs/en/mutations.md
+++ b/docs/en/mutations.md
@@ -168,7 +168,7 @@ export default {
   methods: {
     ...mapMutations({
       addAlias: function(commit) {
-          commit('increment') //map `this.addAlias(amount)` to `this.$store.commit('increment', amount)`
+          commit('increment') //map `this.addAlias()` to `this.$store.commit('increment')`
       }
     })
   }

--- a/docs/en/mutations.md
+++ b/docs/en/mutations.md
@@ -193,7 +193,7 @@ export default {
     }),
     ...mapMutations('moduleName', {
       addAlias: function(commit) {
-          commit('increment') //map `this.addAlias(amount)` to `this.$store.commit('increment', amount)`
+          commit('increment') //map `this.addAlias()` to `this.$store.commit('increment')`
       }
     })
   }

--- a/docs/en/state.md
+++ b/docs/en/state.md
@@ -81,10 +81,57 @@ export default {
 }
 ```
 
+When using a normal function in above exapmle, the normal function also exposes `getters` as the second argument in addition to the first `state` parameter:
+
+``` js
+// in full builds helpers are exposed as Vuex.mapState
+import { mapState } from 'vuex'
+
+export default {
+  // ...
+  computed: mapState({
+    // to access local state with `this`, a normal function must be used
+    countPlusLocalState (state, getters) {
+      return state.count + this.localCount + getters.annother
+    }
+  })
+}
+```
+
 We can also pass a string array to `mapState` when the name of a mapped computed property is same as a state sub tree name.
 
 ``` js
 computed: mapState([
+  // map this.count to store.state.count
+  'count'
+])
+```
+
+`mapState` can also receive a module name as the first argument so as to access state of module with namespace:
+
+``` js
+// 在单独构建的版本中辅助函数为 Vuex.mapState
+import { mapState } from 'vuex'
+
+export default {
+  // ...
+  computed: mapState('moduleName', {
+    // arrow functions can make the code very succinct!
+    count: state => state.count,
+
+    // passing the string value 'count' is same as `state => state.count`
+    countAlias: 'count',
+
+    // to access local state with `this`, a normal function must be used
+    countPlusLocalState (state) {
+      return state.count + this.localCount
+    }
+  })
+}
+```
+
+``` js
+computed: mapState('moduleName', [
   // map this.count to store.state.count
   'count'
 ])

--- a/docs/zh-cn/actions.md
+++ b/docs/zh-cn/actions.md
@@ -118,6 +118,49 @@ export default {
 }
 ```
 
+使用 mapActions 辅助函数进行映射时也可以采用下面这种方式：
+
+``` js
+import { mapActions } from 'vuex'
+
+export default {
+  // ...
+  methods: {
+    ...mapActions({
+      addAlias: function (dispatch) {
+        dispatch('increment') // 将 `this.addAlias(amount)` 映射为 `this.$store.dispatch('increment', amount)`
+      }
+    })
+  }
+}
+```
+上面这几种映射方式也都支持传递模块名称给mapActions第一个参数，从而提交Action至带命名空间的模块：
+
+``` js
+import { mapActions } from 'vuex'
+
+export default {
+  // ...
+  methods: {
+    ...mapActions('moduleName', [
+      'increment', // 将 `this.increment()` 映射为 `this.$store.dispatch('increment')`
+
+      // `mapActions` 也支持载荷：
+      'incrementBy' // 将 `this.incrementBy(amount)` 映射为 `this.$store.dispatch('incrementBy', amount)`
+    ]),
+    ...mapActions('moduleName', {
+      add: 'increment' // 将 `this.add()` 映射为 `this.$store.dispatch('increment')`
+    }),
+    ...mapActions('moduleName', {
+      addAlias: function (dispatch) {
+        dispatch('increment') // 将 `this.addAlias(amount)` 映射为 `this.$store.dispatch('increment', amount)`
+      }
+    })
+  }
+}
+```
+
+
 ### 组合 Action
 
 Action 通常是异步的，那么如何知道 action 什么时候结束呢？更重要的是，我们如何才能组合多个 action，以处理更加复杂的异步流程？

--- a/docs/zh-cn/actions.md
+++ b/docs/zh-cn/actions.md
@@ -128,7 +128,7 @@ export default {
   methods: {
     ...mapActions({
       addAlias: function (dispatch) {
-        dispatch('increment') // 将 `this.addAlias(amount)` 映射为 `this.$store.dispatch('increment', amount)`
+        dispatch('increment') // 将 `this.addAlias()` 映射为 `this.$store.dispatch('increment')`
       }
     })
   }
@@ -153,7 +153,7 @@ export default {
     }),
     ...mapActions('moduleName', {
       addAlias: function (dispatch) {
-        dispatch('increment') // 将 `this.addAlias(amount)` 映射为 `this.$store.dispatch('increment', amount)`
+        dispatch('increment') // 将 `this.addAlias()` 映射为 `this.$store.dispatch('increment')`
       }
     })
   }

--- a/docs/zh-cn/mutations.md
+++ b/docs/zh-cn/mutations.md
@@ -157,6 +157,49 @@ export default {
   }
 }
 ```
+使用 `mapMutations` 辅助函数进行映射时也可以采用下面这种方式：
+
+``` js
+import { mapMutations } from 'vuex'
+
+export default {
+  // ...
+  methods: {
+    ...mapMutations({
+      addAlias: function(commit) {
+          commit('increment') //将 `this.addAlias(amount)` 映射为 `this.$store.commit('increment', amount)`
+      }
+    })
+  }
+}
+```
+
+上面这几种映射方式也都支持传递模块名称给mapMutations第一个参数，从而提交Mutattion至带命名空间的模块：
+
+``` js
+import { mapMutations } from 'vuex'
+
+export default {
+  // ...
+  methods: {
+    ...mapMutations('moduleName', [
+      'increment', // 将 `this.increment()` 映射为 `this.$store.commit('increment')`
+
+      // `mapMutations` 也支持载荷：
+      'incrementBy' // 将 `this.incrementBy(amount)` 映射为 `this.$store.commit('incrementBy', amount)`
+    ]),
+    ...mapMutations('moduleName', {
+      add: 'increment' // 将 `this.add()` 映射为 `this.$store.commit('increment')`
+    }),
+    ...mapMutations('moduleName', {
+      addAlias: function(commit) {
+          commit('increment') //将 `this.addAlias(amount)` 映射为 `this.$store.commit('increment', amount)`
+      }
+    })
+  }
+}
+```
+
 
 ### 下一步：Action
 

--- a/docs/zh-cn/mutations.md
+++ b/docs/zh-cn/mutations.md
@@ -193,7 +193,7 @@ export default {
     }),
     ...mapMutations('moduleName', {
       addAlias: function(commit) {
-          commit('increment') //将 `this.addAlias(amount)` 映射为 `this.$store.commit('increment', amount)`
+          commit('increment') //将 `this.addAlias()` 映射为 `this.$store.commit('increment')`
       }
     })
   }

--- a/docs/zh-cn/state.md
+++ b/docs/zh-cn/state.md
@@ -80,10 +80,57 @@ export default {
 }
 ```
 
+使用常规函数时，除暴露state参数外，还会暴露getters：
+
+``` js
+// 在单独构建的版本中辅助函数为 Vuex.mapState
+import { mapState } from 'vuex'
+
+export default {
+  // ...
+  computed: mapState({
+    // 为了能够使用 `this` 获取局部状态，必须使用常规函数
+    countPlusLocalState (state, getters) {
+      return state.count + this.localCount + getters.annother
+    }
+  })
+}
+```
+
 当映射的计算属性的名称与 state 的子节点名称相同时，我们也可以给 `mapState` 传一个字符串数组。
 
 ``` js
 computed: mapState([
+  // 映射 this.count 为 store.state.count
+  'count'
+])
+```
+
+以上几种方式都支持给mapState函数提交模块名称作为第一个参数，从而获取带命名空间模块的状态：
+
+``` js
+// 在单独构建的版本中辅助函数为 Vuex.mapState
+import { mapState } from 'vuex'
+
+export default {
+  // ...
+  computed: mapState('moduleName', {
+    // 箭头函数可使代码更简练
+    count: state => state.count,
+
+    // 传字符串参数 'count' 等同于 `state => state.count`
+    countAlias: 'count',
+
+    // 为了能够使用 `this` 获取局部状态，必须使用常规函数
+    countPlusLocalState (state) {
+      return state.count + this.localCount
+    }
+  })
+}
+```
+
+``` js
+computed: mapState('moduleName', [
   // 映射 this.count 为 store.state.count
   'count'
 ])


### PR DESCRIPTION
1, point out an unmentioned way of mapMutations helper mapping 
2, point out an unmentioned way of mapActions helper mapping 
3. point out that getters will be exposed as second parameter when maping States as normal function
4. point out that mapMutations can also receive a module name as the first argument so as to commit 
    mutattion to a module with namespace.
5. point out that mapActions can also receive a module name as the first argument so as to commit 
    mutattion to a module with namespace.
6. point out that mapState can also receive a module name as the first argument so as to commit 
    mutattion to a module with namespace.
