### PR TITLE
fix: avoid to call root state function twice

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -25,13 +25,6 @@ export class Store {
       strict = false
     } = options
 
-    let {
-      state = {}
-    } = options
-    if (typeof state === 'function') {
-      state = state() || {}
-    }
-
     // store internal state
     this._committing = false
     this._actions = Object.create(null)
@@ -55,6 +48,8 @@ export class Store {
 
     // strict mode
     this.strict = strict
+
+    const state = this._modules.root.state
 
     // init root module.
     // this also recursively registers all sub-modules

--- a/test/unit/store.spec.js
+++ b/test/unit/store.spec.js
@@ -286,6 +286,14 @@ describe('Store', () => {
     expect(store.state.a).toBe(3)
   })
 
+  it('should not call root state function twice', () => {
+    const spy = jasmine.createSpy().and.returnValue(1)
+    new Vuex.Store({
+      state: spy
+    })
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
   it('subscribe: should handle subscriptions / unsubscriptions', () => {
     const subscribeSpy = jasmine.createSpy()
     const secondSubscribeSpy = jasmine.createSpy()


### PR DESCRIPTION
fix #1030 

Just using the state object of module instead of manually calling the function in the store constructor.