### PR TITLE
shopping-cart example: 'lastCheckout' should be 'checkoutStatus' to have any impact

### DIFF
--- a/examples/shopping-cart/store/modules/cart.js
+++ b/examples/shopping-cart/store/modules/cart.js
@@ -29,7 +29,7 @@ const actions = {
 // mutations
 const mutations = {
   [types.ADD_TO_CART] (state, { id }) {
-    state.lastCheckout = null
+    state.checkoutStatus = null
     const record = state.added.find(p => p.id === id)
     if (!record) {
       state.added.push({


### PR DESCRIPTION
inside [types.ADD_TO_CART] ...

    state.lastCheckout = null // seems to do nothing
    state.checkoutStatus = null // this makes more sense, hides checkout-msg when new item gets added to cart