### PR TITLE
Unused paramater : getter

### DIFF
--- a/docs/en/getters.md
+++ b/docs/en/getters.md
@@ -68,7 +68,7 @@ You can also pass arguments to getters by returning a function. This is particul
 ```js
 getters: {
   // ...
-  getTodoById: (state, getters) => (id) => {
+  getTodoById: (state) => (id) => {
     return state.todos.find(todo => todo.id === id)
   }
 }


### PR DESCRIPTION
In the current getter example, there is no need of including `getters` dependency as we are not using it while defining the method to search by Id, `getTodoById`