### PR TITLE
fix: fix #1032, relax vue typing in helpers

### DIFF
--- a/types/helpers.d.ts
+++ b/types/helpers.d.ts
@@ -5,6 +5,7 @@ type Dictionary<T> = { [key: string]: T };
 type Computed = () => any;
 type MutationMethod = (...args: any[]) => void;
 type ActionMethod = (...args: any[]) => Promise<any>;
+type CustomVue = Vue & Dictionary<any>
 
 interface Mapper<R> {
   (map: string[]): Dictionary<R>;
@@ -17,26 +18,26 @@ interface MapperWithNamespace<R> {
 }
 
 interface FunctionMapper<F, R> {
-  (map: Dictionary<(this: typeof Vue, fn: F, ...args: any[]) => any>): Dictionary<R>;
+  (map: Dictionary<(this: CustomVue, fn: F, ...args: any[]) => any>): Dictionary<R>;
 }
 
 interface FunctionMapperWithNamespace<F, R> {
   (
     namespace: string,
-    map: Dictionary<(this: typeof Vue, fn: F, ...args: any[]) => any>
+    map: Dictionary<(this: CustomVue, fn: F, ...args: any[]) => any>
   ): Dictionary<R>;
 }
 
 interface MapperForState {
   <S>(
-    map: Dictionary<(this: typeof Vue, state: S, getters: any) => any>
+    map: Dictionary<(this: CustomVue, state: S, getters: any) => any>
   ): Dictionary<Computed>;
 }
 
 interface MapperForStateWithNamespace {
   <S>(
     namespace: string,
-    map: Dictionary<(this: typeof Vue, state: S, getters: any) => any>
+    map: Dictionary<(this: CustomVue, state: S, getters: any) => any>
   ): Dictionary<Computed>;
 }
 

--- a/types/test/helpers.ts
+++ b/types/test/helpers.ts
@@ -41,7 +41,10 @@ new Vue({
       k: "k"
     }),
     helpers.mapState({
-      k: (state: any, getters: any) => state.k + getters.k
+      k: (state: any, getters: any) => state.k + getters.k,
+      useThis(state: any, getters: any) {
+        return state.k + getters.k + this.whatever
+      }
     }),
 
     helpers.mapGetters(["l"]),


### PR DESCRIPTION
Relax `this` used in `mapState` helpers. If user want more specific typing, they need manual annotation.