### PR TITLE
docs: update watch() description

### DIFF
--- a/docs/en/api.md
+++ b/docs/en/api.md
@@ -140,7 +140,7 @@ const store = new Vuex.Store({ ...options })
 
 - **`watch(getter: Function, cb: Function, options?: Object)`**
 
-  Reactively watch a getter function's return value, and call the callback when the value changes. The getter receives the store's state as the only argument. Accepts an optional options object that takes the same options as Vue's `vm.$watch` method.
+  Reactively watch a getter function's return value, and call the callback when the value changes. The getter receives the store's state as the first argument, and getters as the second argument. Accepts an optional options object that takes the same options as Vue's `vm.$watch` method.
 
   To stop watching, call the returned handle function.
 


### PR DESCRIPTION
Description of the `watch()` function is not accurate, [getter receives two arguments](https://github.com/vuejs/vuex/blob/dev/src/store.js#L150). 