### PR TITLE
Update testing.md

### DIFF
--- a/docs/en/testing.md
+++ b/docs/en/testing.md
@@ -4,7 +4,7 @@ The main parts we want to unit test in Vuex are mutations and actions.
 
 ### Testing Mutations
 
-Mutations are very straightforward to test, because they are just functions that completely rely on their arguments. One trick is that if you are using ES2015 modules and put your mutations inside your `store.js` file, in addition to the default export, you can also export the mutations as a named export:
+Mutations are very straightforward to test, because they are just functions that completely rely on their arguments. One trick is that if you are using ES2015 modules and put your mutations inside your `store.js` file, in addition to the default export, you should also export the mutations as a named export:
 
 ``` js
 const state = { ... }


### PR DESCRIPTION
Word 'can' implies the user has a choice to do that or not, but in this case it is obligatory to export the mutations as a named export. Took me a while to make the test work :)