### PR TITLE
Add isDebug util

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,3 +1,5 @@
+import { isDebug } from './util'
+
 export const mapState = normalizeNamespace((namespace, states) => {
   const res = {}
   normalizeMap(states).forEach(({ key, val }) => {
@@ -50,7 +52,7 @@ export const mapGetters = normalizeNamespace((namespace, getters) => {
       if (namespace && !getModuleByNamespace(this.$store, 'mapGetters', namespace)) {
         return
       }
-      if (process.env.NODE_ENV !== 'production' && !(val in this.$store.getters)) {
+      if (isDebug() && !(val in this.$store.getters)) {
         console.error(`[vuex] unknown getter: ${val}`)
         return
       }
@@ -109,7 +111,7 @@ function normalizeNamespace (fn) {
 
 function getModuleByNamespace (store, helper, namespace) {
   const module = store._modulesNamespaceMap[namespace]
-  if (process.env.NODE_ENV !== 'production' && !module) {
+  if (isDebug() && !module) {
     console.error(`[vuex] module namespace not found in ${helper}(): ${namespace}`)
   }
   return module

--- a/src/module/module-collection.js
+++ b/src/module/module-collection.js
@@ -1,5 +1,5 @@
 import Module from './module'
-import { assert, forEachValue } from '../util'
+import { assert, isDebug, forEachValue } from '../util'
 
 export default class ModuleCollection {
   constructor (rawRootModule) {
@@ -26,7 +26,7 @@ export default class ModuleCollection {
   }
 
   register (path, rawModule, runtime = true) {
-    if (process.env.NODE_ENV !== 'production') {
+    if (isDebug()) {
       assertRawModule(path, rawModule)
     }
 
@@ -56,7 +56,7 @@ export default class ModuleCollection {
 }
 
 function update (path, targetModule, newModule) {
-  if (process.env.NODE_ENV !== 'production') {
+  if (isDebug()) {
     assertRawModule(path, newModule)
   }
 
@@ -67,7 +67,7 @@ function update (path, targetModule, newModule) {
   if (newModule.modules) {
     for (const key in newModule.modules) {
       if (!targetModule.getChild(key)) {
-        if (process.env.NODE_ENV !== 'production') {
+        if (isDebug()) {
           console.warn(
             `[vuex] trying to add a new module '${key}' on hot reloading, ` +
             'manual reload is needed'

--- a/src/store.js
+++ b/src/store.js
@@ -1,7 +1,7 @@
 import applyMixin from './mixin'
 import devtoolPlugin from './plugins/devtool'
 import ModuleCollection from './module/module-collection'
-import { forEachValue, isObject, isPromise, assert } from './util'
+import { forEachValue, isDebug, isObject, isPromise, assert } from './util'
 
 let Vue // bind on install
 
@@ -14,7 +14,7 @@ export class Store {
       install(window.Vue)
     }
 
-    if (process.env.NODE_ENV !== 'production') {
+    if (isDebug()) {
       assert(Vue, `must call Vue.use(Vuex) before creating a store instance.`)
       assert(typeof Promise !== 'undefined', `vuex requires a Promise polyfill in this browser.`)
       assert(this instanceof Store, `Store must be called with the new operator.`)
@@ -73,7 +73,7 @@ export class Store {
   }
 
   set state (v) {
-    if (process.env.NODE_ENV !== 'production') {
+    if (isDebug()) {
       assert(false, `Use store.replaceState() to explicit replace store state.`)
     }
   }
@@ -89,7 +89,7 @@ export class Store {
     const mutation = { type, payload }
     const entry = this._mutations[type]
     if (!entry) {
-      if (process.env.NODE_ENV !== 'production') {
+      if (isDebug()) {
         console.error(`[vuex] unknown mutation type: ${type}`)
       }
       return
@@ -102,7 +102,7 @@ export class Store {
     this._subscribers.forEach(sub => sub(mutation, this.state))
 
     if (
-      process.env.NODE_ENV !== 'production' &&
+      isDebug() &&
       options && options.silent
     ) {
       console.warn(
@@ -122,7 +122,7 @@ export class Store {
     const action = { type, payload }
     const entry = this._actions[type]
     if (!entry) {
-      if (process.env.NODE_ENV !== 'production') {
+      if (isDebug()) {
         console.error(`[vuex] unknown action type: ${type}`)
       }
       return
@@ -144,7 +144,7 @@ export class Store {
   }
 
   watch (getter, cb, options) {
-    if (process.env.NODE_ENV !== 'production') {
+    if (isDebug()) {
       assert(typeof getter === 'function', `store.watch only accepts a function.`)
     }
     return this._watcherVM.$watch(() => getter(this.state, this.getters), cb, options)
@@ -159,7 +159,7 @@ export class Store {
   registerModule (path, rawModule, options = {}) {
     if (typeof path === 'string') path = [path]
 
-    if (process.env.NODE_ENV !== 'production') {
+    if (isDebug()) {
       assert(Array.isArray(path), `module path must be a string or an Array.`)
       assert(path.length > 0, 'cannot register the root module by using registerModule.')
     }
@@ -173,7 +173,7 @@ export class Store {
   unregisterModule (path) {
     if (typeof path === 'string') path = [path]
 
-    if (process.env.NODE_ENV !== 'production') {
+    if (isDebug()) {
       assert(Array.isArray(path), `module path must be a string or an Array.`)
     }
 
@@ -324,7 +324,7 @@ function makeLocalContext (store, namespace, path) {
 
       if (!options || !options.root) {
         type = namespace + type
-        if (process.env.NODE_ENV !== 'production' && !store._actions[type]) {
+        if (isDebug() && !store._actions[type]) {
           console.error(`[vuex] unknown local action type: ${args.type}, global type: ${type}`)
           return
         }
@@ -340,7 +340,7 @@ function makeLocalContext (store, namespace, path) {
 
       if (!options || !options.root) {
         type = namespace + type
-        if (process.env.NODE_ENV !== 'production' && !store._mutations[type]) {
+        if (isDebug() && !store._mutations[type]) {
           console.error(`[vuex] unknown local mutation type: ${args.type}, global type: ${type}`)
           return
         }
@@ -423,7 +423,7 @@ function registerAction (store, type, handler, local) {
 
 function registerGetter (store, type, rawGetter, local) {
   if (store._wrappedGetters[type]) {
-    if (process.env.NODE_ENV !== 'production') {
+    if (isDebug()) {
       console.error(`[vuex] duplicate getter key: ${type}`)
     }
     return
@@ -440,7 +440,7 @@ function registerGetter (store, type, rawGetter, local) {
 
 function enableStrictMode (store) {
   store._vm.$watch(function () { return this._data.$$state }, () => {
-    if (process.env.NODE_ENV !== 'production') {
+    if (isDebug()) {
       assert(store._committing, `Do not mutate vuex store state outside mutation handlers.`)
     }
   }, { deep: true, sync: true })
@@ -459,7 +459,7 @@ function unifyObjectStyle (type, payload, options) {
     type = type.type
   }
 
-  if (process.env.NODE_ENV !== 'production') {
+  if (isDebug()) {
     assert(typeof type === 'string', `Expects string as the type, but found ${typeof type}.`)
   }
 
@@ -468,7 +468,7 @@ function unifyObjectStyle (type, payload, options) {
 
 export function install (_Vue) {
   if (Vue && _Vue === Vue) {
-    if (process.env.NODE_ENV !== 'production') {
+    if (isDebug()) {
       console.error(
         '[vuex] already installed. Vue.use(Vuex) should be called only once.'
       )

--- a/src/util.js
+++ b/src/util.js
@@ -53,6 +53,10 @@ export function forEachValue (obj, fn) {
   Object.keys(obj).forEach(key => fn(obj[key], key))
 }
 
+export function isDebug () {
+  return process.env.NODE_ENV !== 'production'
+}
+
 export function isObject (obj) {
   return obj !== null && typeof obj === 'object'
 }


### PR DESCRIPTION
On a lot of places in code we have NODE_ENV check to see if it is production env. This PR introduces `isDebug` util function that does the same, but it is a lot cleaner and shorter.