### PR TITLE
[Shopping cart example] Use `product` instead of abbreviation

### DIFF
--- a/examples/shopping-cart/components/Cart.vue
+++ b/examples/shopping-cart/components/Cart.vue
@@ -3,8 +3,8 @@
     <h2>Your Cart</h2>
     <p v-show="!products.length"><i>Please add some products to cart.</i></p>
     <ul>
-      <li v-for="p in products">
-        {{ p.title }} - {{ p.price | currency }} x {{ p.quantity }}
+      <li v-for="product in products">
+        {{ product.title }} - {{ product.price | currency }} x {{ product.quantity }}
       </li>
     </ul>
     <p>Total: {{ total | currency }}</p>
@@ -23,8 +23,8 @@ export default {
       checkoutStatus: 'checkoutStatus'
     }),
     total () {
-      return this.products.reduce((total, p) => {
-        return total + p.price * p.quantity
+      return this.products.reduce((total, product) => {
+        return total + product.price * product.quantity
       }, 0)
     }
   },

--- a/examples/shopping-cart/components/ProductList.vue
+++ b/examples/shopping-cart/components/ProductList.vue
@@ -1,11 +1,11 @@
 <template>
   <ul>
-    <li v-for="p in products">
-      {{ p.title }} - {{ p.price | currency }}
+    <li v-for="product in products">
+      {{ product.title }} - {{ product.price | currency }}
       <br>
       <button
-        :disabled="!p.inventory"
-        @click="addToCart(p)">
+        :disabled="!product.inventory"
+        @click="addToCart(product)">
         Add to cart
       </button>
     </li>

--- a/examples/shopping-cart/store/getters.js
+++ b/examples/shopping-cart/store/getters.js
@@ -1,6 +1,6 @@
 export const cartProducts = state => {
   return state.cart.added.map(({ id, quantity }) => {
-    const product = state.products.all.find(p => p.id === id)
+    const product = state.products.all.find(product => product.id === id)
     return {
       title: product.title,
       price: product.price,

--- a/examples/shopping-cart/store/modules/cart.js
+++ b/examples/shopping-cart/store/modules/cart.js
@@ -30,7 +30,7 @@ const actions = {
 const mutations = {
   [types.ADD_TO_CART] (state, { id }) {
     state.checkoutStatus = null
-    const record = state.added.find(p => p.id === id)
+    const record = state.added.find(product => product.id === id)
     if (!record) {
       state.added.push({
         id,

--- a/examples/shopping-cart/store/modules/products.js
+++ b/examples/shopping-cart/store/modules/products.js
@@ -27,7 +27,7 @@ const mutations = {
   },
 
   [types.ADD_TO_CART] (state, { id }) {
-    state.all.find(p => p.id === id).inventory--
+    state.all.find(product => product.id === id).inventory--
   }
 }
 


### PR DESCRIPTION
Replace the `p` variable name abbreviation with `product` to make the example easier to read.