### PR TITLE
Buffer mutations for vue-devtools

### DIFF
--- a/src/plugins/devtool.js
+++ b/src/plugins/devtool.js
@@ -6,6 +6,9 @@ export default function devtoolPlugin (store) {
   if (!devtoolHook) return
 
   store._devtoolHook = devtoolHook
+  // buffer mutations for devtools
+  // it will later be removed by devtools
+  store._devtoolBuffer = []
 
   devtoolHook.emit('vuex:init', store)
 
@@ -15,5 +18,10 @@ export default function devtoolPlugin (store) {
 
   store.subscribe((mutation, state) => {
     devtoolHook.emit('vuex:mutation', mutation, state)
+
+    // if buffer exists push mutation for later use
+    if (Array.isArray(store._devtoolBuffer)) {
+      store._devtoolBuffer.push(mutation)
+    }
   })
 }

--- a/src/plugins/devtool.js
+++ b/src/plugins/devtool.js
@@ -8,7 +8,9 @@ export default function devtoolPlugin (store) {
   store._devtoolHook = devtoolHook
   // buffer mutations for devtools
   // it will later be removed by devtools
-  store._devtoolBuffer = []
+  if (devtoolHook.supportsVuexBuffer) {
+    store._devtoolBuffer = []
+  }
 
   devtoolHook.emit('vuex:init', store)
 

--- a/src/plugins/devtool.js
+++ b/src/plugins/devtool.js
@@ -22,7 +22,7 @@ export default function devtoolPlugin (store) {
     devtoolHook.emit('vuex:mutation', mutation, state)
 
     // if buffer exists push mutation for later use
-    if (Array.isArray(store._devtoolBuffer)) {
+    if (store._devtoolBuffer) {
       store._devtoolBuffer.push(mutation)
     }
   })


### PR DESCRIPTION
This PR provides proof-of-concept for buffering mutations for devtools to use. I am not really happy with this code as it relies on setting `store._devtoolsBuffer = undefined` after vue-devtools boots up in order to prevent memory leak. Anyway, thanks to this solution all mutations are inspectable in devtools.
  
Shouldn't be merge until vuejs/vue-devtools#491 is deployed or this code is refactored!

Closes vuejs/vue-devtools#408

I'll be happy to get some feedback