### PR TITLE
fix(types): allow a function type for root `state` option

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -77,7 +77,7 @@ export interface CommitOptions {
 }
 
 export interface StoreOptions<S> {
-  state?: S;
+  state?: S | (() => S);
   getters?: GetterTree<S, S>;
   actions?: ActionTree<S, S>;
   mutations?: MutationTree<S>;

--- a/types/test/index.ts
+++ b/types/test/index.ts
@@ -96,6 +96,15 @@ namespace RootDefaultModule {
   });
 }
 
+namespace InitialStateFunction {
+  const store = new Vuex.Store({
+    state: () => ({
+      value: 1
+    })
+  });
+  const n: number = store.state.value;
+}
+
 namespace NestedModules {
   interface RootState {
     a: {


### PR DESCRIPTION
This PR allows to pass a function for root `state` option as same as modules in TypeScript.