### PR TITLE
export ActionHandler

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -86,8 +86,8 @@ export interface StoreOptions<S> {
   strict?: boolean;
 }
 
-type ActionHandler<S, R> = (injectee: ActionContext<S, R>, payload: any) => any;
-interface ActionObject<S, R> {
+export type ActionHandler<S, R> = (injectee: ActionContext<S, R>, payload: any) => any;
+export interface ActionObject<S, R> {
   root?: boolean;
   handler: ActionHandler<S, R>;
 }


### PR DESCRIPTION
- while testing we have methods using this method signature and it would be nice if we did not have define this.

We were running into the issue as reported in https://github.com/Microsoft/TypeScript/issues/7960

So workaround was to do something like
```
type ModuleAction<ModuleState> = (injectee: ActionContext<ModuleState, State>, payload: any) => any;
const loginAction = userActions.login as ModuleAction<UserState>;
```