### PR TITLE
[featrue] dispatch and commit function support multiple parameters

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -40,10 +40,10 @@ export class Store {
     const store = this
     const { dispatch, commit } = this
     this.dispatch = function boundDispatch (type, payload) {
-      return dispatch.call(store, type, payload)
+      return dispatch.apply(store, arguments)
     }
     this.commit = function boundCommit (type, payload, options) {
-      return commit.call(store, type, payload, options)
+      return commit.apply(store, arguments)
     }
 
     // strict mode


### PR DESCRIPTION
In some cases, multiple parameters need to be passed
### Example
```javascript
store.dispatch('add', 'one', 'two', 'three')
store.commit('add', 'one', 'two', 'three')
```