### PR TITLE
docs: Update docs of testAction helper

### DIFF
--- a/docs/en/testing.md
+++ b/docs/en/testing.md
@@ -94,9 +94,9 @@ const testAction = (action, payload, state, expectedMutations, done) => {
     const mutation = expectedMutations[count]
 
     try {
-      expect(mutation.type).to.equal(type)
+      expect(type).to.equal(mutation.type)
       if (payload) {
-        expect(mutation.payload).to.deep.equal(payload)
+        expect(payload).to.deep.equal(mutation.payload)
       }
     } catch (error) {
       done(error)

--- a/docs/fr/testing.md
+++ b/docs/fr/testing.md
@@ -94,9 +94,9 @@ const testAction = (action, args, state, expectedMutations, done) => {
     const mutation = expectedMutations[count]
 
     try {
-      expect(mutation.type).to.equal(type)
+      expect(type).to.equal(mutation.type)
       if (payload) {
-        expect(mutation.payload).to.deep.equal(payload)
+        expect(payload).to.deep.equal(mutation.payload)
       }
     } catch (error) {
       done(error)

--- a/docs/ja/testing.md
+++ b/docs/ja/testing.md
@@ -93,9 +93,9 @@ const testAction = (action, payload, state, expectedMutations, done) => {
     const mutation = expectedMutations[count]
 
     try {
-      expect(mutation.type).to.equal(type)
+      expect(type).to.equal(mutation.type)
       if (payload) {
-        expect(mutation.payload).to.deep.equal(payload)
+        expect(payload).to.deep.equal(mutation.payload)
       }
     } catch (error) {
       done(error)

--- a/docs/kr/testing.md
+++ b/docs/kr/testing.md
@@ -94,9 +94,9 @@ const testAction = (action, payload, state, expectedMutations, done) => {
     const mutation = expectedMutations[count]
 
     try {
-      expect(mutation.type).to.equal(type)
+      expect(type).to.equal(mutation.type)
       if (payload) {
-        expect(mutation.payload).to.deep.equal(payload)
+        expect(payload).to.deep.equal(mutation.payload)
       }
     } catch (error) {
       done(error)

--- a/docs/zh-cn/testing.md
+++ b/docs/zh-cn/testing.md
@@ -93,9 +93,9 @@ const testAction = (action, args, state, expectedMutations, done) => {
     const mutation = expectedMutations[count]
 
     try {
-      expect(mutation.type).to.equal(type)
+      expect(type).to.equal(mutation.type)
       if (payload) {
-        expect(mutation.payload).to.deep.equal(payload)
+        expect(payload).to.deep.equal(mutation.payload)
       }
     } catch (error) {
       done(error)


### PR DESCRIPTION
This makes it read & produce the correct error messages

It now reads as `expect(actual).to.equal(expected)`