### PR TITLE
[feat] Add asyncData Method Type to ComponentOptions Module Augmentation

### DIFF
--- a/types/test/vue.ts
+++ b/types/test/vue.ts
@@ -8,7 +8,8 @@ const store = new Vuex.Store({
 });
 
 const vm = new Vue({
-  store
+  store,
+  asyncData: ({ store, route }) => new Promise((resolve, reject) => resolve())
 });
 
 vm.$store.state.value;

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -8,6 +8,7 @@ import { Store } from "./index";
 declare module "vue/types/options" {
   interface ComponentOptions<V extends Vue> {
     store?: Store<any>;
+    asyncData?(opts: { store?: Store<any>, route?: string }): Promise<any>;
   }
 }
 


### PR DESCRIPTION
We use Vue SSR heavily at @algorithmiaio, and we've followed the [Vue SSR-sanctioned means of declaring async data methods](https://ssr.vuejs.org/en/data.html#logic-collocation-with-components).  We've shimmed together our own module augmentation for the `asyncData` method, but given the prevalence of `asyncData` usage throughout the Vue community, it would be nice to standardize the interface.

I was torn as per where this should live - there isn't a repo for SSR, given that it lives in the Vue repo, and ultimately it felt right here with the Vuex project, since `asyncData` and Vuex go hand in hand. 

I've added a test for the new type as well, and let me know if there's anything I can tweak. Cheers!