### PR TITLE
Remove old link to documentation that is outdated

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
   <img width="700px" src="https://raw.githubusercontent.com/vuejs/vuex/dev/docs/.vuepress/public/vuex.png">
 </p>
 
-- [What is Vuex?](http://vuex.vuejs.org/en/intro.html)
 - [Full Documentation](http://vuex.vuejs.org/)
 
 ## Examples


### PR DESCRIPTION
The link "What is Vuex" does point to a 404. Since the "Full Documentation" Link already points to the "What is Vuex"-section that s should be sufficient