### PR TITLE
Add parameter types for store's commit and dispatch methods

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -42,6 +42,7 @@ export interface Dispatch {
 }
 
 export interface Commit {
+  <T, P>(type: T, payload?: P, options?: CommitOptions): void;
   (type: string, payload?: any, options?: CommitOptions): void;
   <P extends Payload>(payloadWithType: P, options?: CommitOptions): void;
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -37,6 +37,7 @@ export declare class Store<S> {
 export declare function install(Vue: typeof _Vue): void;
 
 export interface Dispatch {
+  <T, P>(type: T, payload?: P, options?: DispatchOptions): Promise<any>;
   (type: string, payload?: any, options?: DispatchOptions): Promise<any>;
   <P extends Payload>(payloadWithType: P, options?: DispatchOptions): Promise<any>;
 }


### PR DESCRIPTION
This will enable users to provide type safe parameters for the commit and dispatch methods.

Example: 
```javascript
import * as mutations from '@/store/mutation-types';
import uuid from 'uuid'

interface AddTodoRequestPayload {
  title: string;
  text: string;
}

interface AddTodoPayload {
  uid: string
  title: string;
  text: string;
}

const ADD_TODO_REQUEST = 'ADD_TODO_REQUEST';
type ADD_TODO_REQUEST = typeof ADD_TODO_REQUEST;

const actions = {
  [ADD_TODO_REQUEST]({ commit }: { commit: Commit }, payload: AddTodoRequestPayload) {
    const uid: string = uuid();
    commit<mutations.types, AddTodoPayload>(
      mutations.ADD_TODO,
      { uid: uid,  title: 'todo title', text: 'todo text' },
    );
  },
};
```