### PR TITLE
Reverse compatable setters for mapState #1085

### DIFF
--- a/test/unit/helpers.spec.js
+++ b/test/unit/helpers.spec.js
@@ -94,6 +94,108 @@ describe('Helpers', () => {
     expect(vm.value.b).toBeUndefined()
   })
 
+  it('mapState (object with string get/set)', () => {
+    const store = new Vuex.Store({
+      state: { count: 1 },
+      mutations: {
+        count (state, count) {
+          state.count = count
+        }
+      }
+    })
+    const vm = new Vue({
+      store,
+      computed: mapState({ count: { get: 'count', set: 'count' }})
+    })
+    expect(vm.count).toBe(1)
+    vm.count++
+    expect(vm.count).toBe(2)
+  })
+
+  it('mapState (object with arrow function get/set)', () => {
+    const store = new Vuex.Store({
+      state: { count: 1 },
+      mutations: {
+        COUNT (state, count) {
+          state.count = count
+        }
+      }
+    })
+    const vm = new Vue({
+      store,
+      computed: mapState({
+        count: {
+          get: state => state.count,
+          set: ({ commit }, value) => commit('COUNT', value)
+        }})
+    })
+    expect(vm.count).toBe(1)
+    vm.count++
+    expect(vm.count).toBe(2)
+  })
+
+  it('mapState (object with function get/set)', () => {
+    const store = new Vuex.Store({
+      state: { count: 1 },
+      mutations: {
+        COUNT (state, count) {
+          state.count = count
+        }
+      }
+    })
+    const vm = new Vue({
+      store,
+      computed: mapState({
+        count: {
+          get (state) {
+            return state.count
+          },
+          set ({ commit }, value) {
+            commit('COUNT', value + this.value)
+          }
+        }
+      }),
+      data () {
+        return { value: 2 }
+      }
+    })
+    expect(vm.count).toBe(1)
+    vm.count++
+    expect(vm.count).toBe(4)
+  })
+
+  it('mapState (get/set with namespaced module)', () => {
+    const store = new Vuex.Store({
+      modules: {
+        foo: {
+          namespaced: true,
+          state: { count: 1 },
+          mutations: {
+            COUNT (state, count) {
+              state.count = count
+            }
+          }
+        }
+      }
+    })
+    const vm = new Vue({
+      store,
+      computed: mapState('foo', {
+        count: {
+          get: (state, getters) => {
+            return state.count
+          },
+          set: ({ commit }, count) => {
+            commit('COUNT', count)
+          }
+        }
+      })
+    })
+    expect(vm.count).toBe(1)
+    vm.count++
+    expect(vm.count).toBe(2)
+  })
+
   it('mapMutations (array)', () => {
     const store = new Vuex.Store({
       state: { count: 0 },


### PR DESCRIPTION
In response to issue #1085

This PR adds optional setters to mapState that should be intuitive to people familiar with vue's computed setters and vuex's mapMutations helper function. 

The change can be made without breaking existing usage of the mapState function.

Setters mimic rules for mapMutations (a string argument commits a matching mutation, function arguments are dispatched with a context)

PR includes unit tests for above behaviors including namespaces.

Unchanged Behavior:
```
computed: {
  ...mapState(['count'])
  // -- or --
  ...mapState({
    count: 'count'
  })
  // -- or -- 
  ...mapState({
    count: state => state.count
  })
```

Added Behavior:
```
computed: {
  ...mapState({
    count: {
      get: 'count', //functions identically to ...mapState(['count'])
      set: 'count'  //commit('count', ...args)
    },
    data: {
      get: (state) => state.data,
      set: ({commit}, value) => commit('data', value);
    },
  })
}
```

The two behaviors can be mixed:
```
computed: {
  ...mapState({
    count: 'count',
    data: {
      get: 'data',
      set: 'data'
    }
  })
}
```