### PR TITLE
feat: add type annotation for the context of actions and mutations

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -28,7 +28,7 @@ export declare class Store<S> {
 
   hotUpdate(options: {
     actions?: ActionTree<S, S>;
-    mutations?: MutationTree<S, S>;
+    mutations?: MutationTree<S>;
     getters?: GetterTree<S, S>;
     modules?: ModuleTree<S>;
   }): void;
@@ -48,7 +48,6 @@ export interface Commit {
 
 export interface ActionContext<S, R> {
   dispatch: Dispatch;
-
   commit: Commit;
   state: S;
   getters: any;
@@ -81,7 +80,7 @@ export interface StoreOptions<S> {
   state?: S;
   getters?: GetterTree<S, S>;
   actions?: ActionTree<S, S>;
-  mutations?: MutationTree<S, S>;
+  mutations?: MutationTree<S>;
   modules?: ModuleTree<S>;
   plugins?: Plugin<S>[];
   strict?: boolean;
@@ -95,7 +94,7 @@ export interface ActionObject<S, R> {
 
 export type Getter<S, R> = (state: S, getters: any, rootState: R, rootGetters: any) => any;
 export type Action<S, R> = ActionHandler<S, R> | ActionObject<S, R>;
-export type Mutation<S, R> = (this: Store<R>, state: S, payload: any) => any;
+export type Mutation<S> = (state: S, payload: any) => any;
 export type Plugin<S> = (store: Store<S>) => any;
 
 export interface Module<S, R> {
@@ -103,7 +102,7 @@ export interface Module<S, R> {
   state?: S | (() => S);
   getters?: GetterTree<S, R>;
   actions?: ActionTree<S, R>;
-  mutations?: MutationTree<S, R>;
+  mutations?: MutationTree<S>;
   modules?: ModuleTree<R>;
 }
 
@@ -119,8 +118,8 @@ export interface ActionTree<S, R> {
   [key: string]: Action<S, R>;
 }
 
-export interface MutationTree<S, R> {
-  [key: string]: Mutation<S, R>;
+export interface MutationTree<S> {
+  [key: string]: Mutation<S>;
 }
 
 export interface ModuleTree<R> {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -28,7 +28,7 @@ export declare class Store<S> {
 
   hotUpdate(options: {
     actions?: ActionTree<S, S>;
-    mutations?: MutationTree<S>;
+    mutations?: MutationTree<S, S>;
     getters?: GetterTree<S, S>;
     modules?: ModuleTree<S>;
   }): void;
@@ -48,6 +48,7 @@ export interface Commit {
 
 export interface ActionContext<S, R> {
   dispatch: Dispatch;
+
   commit: Commit;
   state: S;
   getters: any;
@@ -80,13 +81,13 @@ export interface StoreOptions<S> {
   state?: S;
   getters?: GetterTree<S, S>;
   actions?: ActionTree<S, S>;
-  mutations?: MutationTree<S>;
+  mutations?: MutationTree<S, S>;
   modules?: ModuleTree<S>;
   plugins?: Plugin<S>[];
   strict?: boolean;
 }
 
-export type ActionHandler<S, R> = (injectee: ActionContext<S, R>, payload: any) => any;
+export type ActionHandler<S, R> = (this: Store<R>, injectee: ActionContext<S, R>, payload: any) => any;
 export interface ActionObject<S, R> {
   root?: boolean;
   handler: ActionHandler<S, R>;
@@ -94,7 +95,7 @@ export interface ActionObject<S, R> {
 
 export type Getter<S, R> = (state: S, getters: any, rootState: R, rootGetters: any) => any;
 export type Action<S, R> = ActionHandler<S, R> | ActionObject<S, R>;
-export type Mutation<S> = (state: S, payload: any) => any;
+export type Mutation<S, R> = (this: Store<R>, state: S, payload: any) => any;
 export type Plugin<S> = (store: Store<S>) => any;
 
 export interface Module<S, R> {
@@ -102,7 +103,7 @@ export interface Module<S, R> {
   state?: S | (() => S);
   getters?: GetterTree<S, R>;
   actions?: ActionTree<S, R>;
-  mutations?: MutationTree<S>;
+  mutations?: MutationTree<S, R>;
   modules?: ModuleTree<R>;
 }
 
@@ -118,8 +119,8 @@ export interface ActionTree<S, R> {
   [key: string]: Action<S, R>;
 }
 
-export interface MutationTree<S> {
-  [key: string]: Mutation<S>;
+export interface MutationTree<S, R> {
+  [key: string]: Mutation<S, R>;
 }
 
 export interface ModuleTree<R> {
@@ -129,5 +130,5 @@ export interface ModuleTree<R> {
 declare const _default: {
   Store: typeof Store;
   install: typeof install;
-}
+};
 export default _default;

--- a/types/test/index.ts
+++ b/types/test/index.ts
@@ -59,6 +59,7 @@ namespace RootModule {
     },
     actions: {
       foo ({ state, getters, dispatch, commit }, payload) {
+        this.state.value;
         state.value;
         getters.count;
         dispatch("bar", {});
@@ -66,7 +67,9 @@ namespace RootModule {
       }
     },
     mutations: {
-      bar (state, payload) {}
+      bar (state, payload) {
+        this.state.value;
+      }
     },
     strict: true
   });
@@ -83,6 +86,7 @@ namespace RootDefaultModule {
     },
     actions: {
       foo ({ state, getters, dispatch, commit }, payload) {
+        this.state.value;
         state.value;
         getters.count;
         dispatch("bar", {});
@@ -90,7 +94,9 @@ namespace RootDefaultModule {
       }
     },
     mutations: {
-      bar (state, payload) {}
+      bar (state, payload) {
+        this.state.value;
+      }
     },
     strict: true
   });
@@ -107,7 +113,10 @@ namespace NestedModules {
       };
       d: {
         value: number;
-      };
+      },
+      e: {
+        value: number;
+      }
     };
   }
 
@@ -145,7 +154,22 @@ namespace NestedModules {
       b: {
         modules: {
           c: module,
-          d: module
+          d: module,
+          e: {
+            state: {
+              value: 0
+            },
+            actions: {
+              foo(context: ActionStore, payload) {
+                this.state.a;
+              }
+            },
+            mutations: {
+              bar(state, payload) {
+                this.state.b.e;
+              }
+            }
+          }
         }
       }
     }

--- a/types/test/index.ts
+++ b/types/test/index.ts
@@ -67,9 +67,7 @@ namespace RootModule {
       }
     },
     mutations: {
-      bar (state, payload) {
-        this.state.value;
-      }
+      bar (state, payload) {}
     },
     strict: true
   });
@@ -94,9 +92,7 @@ namespace RootDefaultModule {
       }
     },
     mutations: {
-      bar (state, payload) {
-        this.state.value;
-      }
+      bar (state, payload) {}
     },
     strict: true
   });
@@ -162,11 +158,6 @@ namespace NestedModules {
             actions: {
               foo(context: ActionStore, payload) {
                 this.state.a;
-              }
-            },
-            mutations: {
-              bar(state, payload) {
-                this.state.b.e;
               }
             }
           }


### PR DESCRIPTION
The handlers for actions and mutations are bound to the store, but there is no type annotation for this behavior. 

This PR will enable us to use `this` as Store in the handlers.