### PR TITLE
docs: Clarify example with namespaced actions

### DIFF
--- a/docs/guide/modules.md
+++ b/docs/guide/modules.md
@@ -209,8 +209,8 @@ computed: {
 },
 methods: {
   ...mapActions([
-    'some/nested/module/foo',
-    'some/nested/module/bar'
+    'some/nested/module/foo', // -> this['some/nested/module/foo']()
+    'some/nested/module/bar' // -> this['some/nested/module/bar']()
   ])
 }
 ```
@@ -226,8 +226,8 @@ computed: {
 },
 methods: {
   ...mapActions('some/nested/module', [
-    'foo',
-    'bar'
+    'foo', // -> this.foo()
+    'bar' // -> this.bar()
   ])
 }
 ```


### PR DESCRIPTION
Guide suggests that these two example are equal, and are different only by syntax. But they are different, and it would be good to clarify that.