### PR TITLE
WIP feat: access namespaced getters using the dot notation

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -236,6 +236,9 @@ function resetStoreVM (store, state, hot) {
       get: () => store._vm[key],
       enumerable: true // for local getters
     })
+    if (key.includes('/')) {
+      mapNamespacedGetter(store.getters, key, () => fn(store))
+    }
   })
 
   // use a Vue instance to store the state tree
@@ -450,6 +453,24 @@ function getNestedState (state, path) {
   return path.length
     ? path.reduce((state, key) => state[key], state)
     : state
+}
+
+function mapNamespacedGetter (gettersObject, path, getterFunction) {
+  const sections = path.split('/')
+  sections.forEach((section, index) => {
+    // if it's the value
+    if (index === sections.length - 1) {
+      Object.defineProperty(gettersObject, section, {
+        get: getterFunction,
+        enumerable: true
+      })
+    } else {
+      if (!gettersObject[section]) {
+        gettersObject[section] = {}
+      }
+      gettersObject = gettersObject[section]
+    }
+  })
 }
 
 function unifyObjectStyle (type, payload, options) {

--- a/test/unit/helpers.spec.js
+++ b/test/unit/helpers.spec.js
@@ -288,6 +288,8 @@ describe('Helpers', () => {
       })
     })
     expect(vm.a).toBe(false)
+    // @TODO move this to an individual test
+    expect(store.getters.foo.hasAny).toBe(false)
     expect(vm.b).toBe(false)
     store.commit('foo/inc')
     expect(vm.a).toBe(true)

--- a/test/unit/modules.spec.js
+++ b/test/unit/modules.spec.js
@@ -547,6 +547,48 @@ describe('Modules', () => {
       store.dispatch('parent/test')
     })
 
+    it('module: prefer root getter when there is a module with the same name', () => {
+      const store = new Vuex.Store({
+        state: {},
+        getters: {
+          users () {
+            return 'root users'
+          }
+        },
+        modules: {
+          users: {
+            namespaced: true
+          }
+        }
+      })
+      expect(store.getters.users).toBe('root users')
+    })
+
+    it('module: warn when root getter has the same name with a namespaced module', () => {
+      spyOn(console, 'warn')
+      new Vuex.Store({
+        getters: {
+          users () {
+            return 'root users'
+          }
+        },
+        modules: {
+          users: {
+            namespaced: true,
+            getters: {
+              users () {
+                return 'module users'
+              }
+            }
+          }
+        }
+      })
+      expect(console.warn).toHaveBeenCalledWith(
+        `[vuex] "users" module's getters are not available under the dot-notation because there is a getter in the root namespace with the same name ("users").`,
+        `If you want to use the dot-notation rename the "users" root getter or the module.`
+      )
+    })
+
     it('dispatching multiple actions in different modules', done => {
       const store = new Vuex.Store({
         modules: {


### PR DESCRIPTION
Add's support for accessing namespaced getters using the dot notation, the same way we do for the `state`. For example: `this.$store.getters.users.newUsers`

Implements https://github.com/vuejs/vuex/issues/1258

## Todo:
- [x] Prefer root getter in case of same naming to not introduce braking changes - @hootlex
- [x] Display warning if root getter has the same the name with a module. Similar to https://github.com/vuejs/vuex/issues/1363 - @hootlex
- [x] Add complete test for namespaced getters - @simplesmiler 
- [x] Add tests for nested, namespaced modules - @simplesmiler 
- [ ] Docs - @hootlex