### PR TITLE
fix bug: examples/todomvc

### DIFF
--- a/examples/todomvc/store/mutations.js
+++ b/examples/todomvc/store/mutations.js
@@ -11,7 +11,12 @@ export const mutations = {
   },
 
   removeTodo (state, todo) {
-    state.todos.splice(state.todos.indexOf(todo), 1)
+    // when edit some one todoItem, clear the todoItem, then press keyboard enter 
+    // because execute @keyup.enter="doneEdit" and @keyup.esc="cancelEdit" (in page TodoItem.vue)
+    // so here will execute twice, so will delete two todoItem
+    // so i suggest change here to 
+    state.todos = state.todos.filter(item => item.id !== todo.id)
+    // state.todos.splice(state.todos.indexOf(todo), 1)
   },
 
   editTodo (state, { todo, text = todo.text, done = todo.done }) {

--- a/examples/todomvc/store/mutations.js
+++ b/examples/todomvc/store/mutations.js
@@ -11,12 +11,7 @@ export const mutations = {
   },
 
   removeTodo (state, todo) {
-    // when edit some one todoItem, clear the todoItem, then press keyboard enter 
-    // because execute @keyup.enter="doneEdit" and @keyup.esc="cancelEdit" (in page TodoItem.vue)
-    // so here will execute twice, so will delete two todoItem
-    // so i suggest change here to 
     state.todos = state.todos.filter(item => item.id !== todo.id)
-    // state.todos.splice(state.todos.indexOf(todo), 1)
   },
 
   editTodo (state, { todo, text = todo.text, done = todo.done }) {


### PR DESCRIPTION
page vuex\examples\todomvc\store\mutations.js,  method:removeTodo.
when edit some one todoItem, clear the todoItem, then press keyboard enter.
because execute @keyup.enter="doneEdit" and @keyup.esc="cancelEdit" (in page TodoItem.vue).
so here will execute twice, so will delete two todoItem.
so i suggest change here to .