### PR TITLE
chore(docs): link to vue docs watch for options

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -156,7 +156,7 @@ const store = new Vuex.Store({ ...options })
 
 -  `watch(fn: Function, callback: Function, options?: Object): Function`
 
-  Reactively watch `fn`'s return value, and call the callback when the value changes. `fn` receives the store's state as the first argument, and getters as the second argument. Accepts an optional options object that takes the same options as Vue's `vm.$watch` method.
+  Reactively watch `fn`'s return value, and call the callback when the value changes. `fn` receives the store's state as the first argument, and getters as the second argument. Accepts an optional options object that takes the same options as [Vue's `vm.$watch` method](https://vuejs.org/v2/api/#watch).
 
   To stop watching, call the returned unwatch function.
 


### PR DESCRIPTION
> Accepts an optional options object that takes the same options as Vue's vm.$watch method.

linking to the actual `watch` of the vue doc might be helpful for others to check options faster. not sure if this is wanted though due to future maintenance efforts.