### PR TITLE
feat(devtool): allow usage in non-browser environments

### DIFF
--- a/src/plugins/devtool.js
+++ b/src/plugins/devtool.js
@@ -1,6 +1,9 @@
-const devtoolHook =
-  typeof window !== 'undefined' &&
-  window.__VUE_DEVTOOLS_GLOBAL_HOOK__
+const target = typeof window !== 'undefined'
+  ? window
+  : typeof global !== 'undefined'
+    ? global
+    : {}
+const devtoolHook = target.__VUE_DEVTOOLS_GLOBAL_HOOK__
 
 export default function devtoolPlugin (store) {
   if (!devtoolHook) return


### PR DESCRIPTION
This allows inspecting vuex state in standalone devtools with non-browser environments such as NativeScript

Changes taken from
https://github.com/vuejs/vue-devtools/blob/4fe7c84d614f1ddf581d65274f30a989b77f9ad3/shells/electron/index.js#L3-L7