### PR TITLE
Add ability to turn off devtools on vuex by passing an off options

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -116,6 +116,19 @@ const store = new Vuex.Store({ ...options })
 
   [Details](../guide/strict.md)
 
+### devtools
+
+- type: `Boolean`
+
+  Passing false tells the Vuex store to not subscribe to devtools plugin.  By default uses the Vue instances devtools setting.  Useful for if you have multiple stores on a single page.
+
+  ``` js
+  {
+    devtools: false
+  }
+  ```
+
+
 ## Vuex.Store Instance Properties
 
 ### state

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -120,7 +120,7 @@ const store = new Vuex.Store({ ...options })
 
 - type: `Boolean`
 
-  Passing false tells the Vuex store to not subscribe to devtools plugin.  By default uses the Vue instances devtools setting.  Useful for if you have multiple stores on a single page.
+  Turn the devtools on or off for a particular vuex instance.  For instance passing false tells the Vuex store to not subscribe to devtools plugin.  Useful for if you have multiple stores on a single page. 
 
   ``` js
   {

--- a/src/store.js
+++ b/src/store.js
@@ -63,7 +63,8 @@ export class Store {
     // apply plugins
     plugins.forEach(plugin => plugin(this))
 
-    if (Vue.config.devtools && options.devtools !== false) {
+    const useDevtools = options.devtools !== undefined ? options.devtools : Vue.config.devtools
+    if (useDevtools) {
       devtoolPlugin(this)
     }
   }

--- a/src/store.js
+++ b/src/store.js
@@ -63,7 +63,7 @@ export class Store {
     // apply plugins
     plugins.forEach(plugin => plugin(this))
 
-    if (Vue.config.devtools) {
+    if (Vue.config.devtools && options.devtools !== false) {
       devtoolPlugin(this)
     }
   }


### PR DESCRIPTION
This PR adds the ability to turn off devtools on a per vuex instance level.  This is useful for cases where you have multiple vuex stores on a single page.  A good example is a scenario where teams maintain their own portions of a single app that are all loaded, some of which will have an independent vuex store.

With this option, on the dev side i could turn this off per instance so that I can debug a single store. 

By default, this mirrors what is already in vuex, it just allows for turning off when specified.

```
const store = new Vuex.Store({
  devtools: false
})
```

Follow through on https://github.com/vuejs/vuex/issues/875
