### PR TITLE
Add helpers to default export type declaration as in sources

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,7 +3,7 @@ import _Vue, { WatchOptions } from "vue";
 // augment typings of Vue.js
 import "./vue";
 
-import { mapActions, mapGetters, mapMutations, mapState } from "./helpers";
+import { mapState, mapMutations, mapGetters, mapActions, createNamespacedHelpers } from "./helpers";
 
 export * from "./helpers";
 
@@ -135,5 +135,6 @@ declare const _default: {
   mapMutations: typeof mapMutations,
   mapGetters: typeof mapGetters,
   mapActions: typeof mapActions,
+  createNamespacedHelpers: typeof createNamespacedHelpers,
 };
 export default _default;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,6 +3,8 @@ import _Vue, { WatchOptions } from "vue";
 // augment typings of Vue.js
 import "./vue";
 
+import { mapActions, mapGetters, mapMutations, mapState } from "./helpers";
+
 export * from "./helpers";
 
 export declare class Store<S> {
@@ -129,5 +131,9 @@ export interface ModuleTree<R> {
 declare const _default: {
   Store: typeof Store;
   install: typeof install;
+  mapState: typeof mapState,
+  mapMutations: typeof mapMutations,
+  mapGetters: typeof mapGetters,
+  mapActions: typeof mapActions,
 };
 export default _default;


### PR DESCRIPTION
Partially based on #1274
Import Vuex.
```ts
import Vuex from "vuex";
```
Using before this PR: 
```ts
(Vuex as any).mapActions(...)
```

Using after:
```
Vuex.mapActions(...)
```