### PR TITLE
Fix false negative when checking `payload: false`

### DIFF
--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -95,9 +95,7 @@ const testAction = (action, payload, state, expectedMutations, done) => {
 
     try {
       expect(type).to.equal(mutation.type)
-      if (mutation.payload !== undefined) {
-        expect(payload).to.deep.equal(mutation.payload)
-      }
+      expect(payload).to.deep.equal(mutation.payload)
     } catch (error) {
       done(error)
     }

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -95,7 +95,7 @@ const testAction = (action, payload, state, expectedMutations, done) => {
 
     try {
       expect(type).to.equal(mutation.type)
-      if (payload !== undefined) {
+      if (mutation.payload !== undefined) {
         expect(payload).to.deep.equal(mutation.payload)
       }
     } catch (error) {

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -95,7 +95,7 @@ const testAction = (action, payload, state, expectedMutations, done) => {
 
     try {
       expect(type).to.equal(mutation.type)
-      if (payload) {
+      if (payload !== undefined) {
         expect(payload).to.deep.equal(mutation.payload)
       }
     } catch (error) {


### PR DESCRIPTION
Here is my example code:
```javascript
    test('commits setContributionId', (done) => {
      const state = {
        comments: []
      }
      testAction(action, 42, state, [
        // ...
        { type: 'isLoading', payload: false}
      ], done)
    })
```
I'm passing `42` as an argument to `testAction` and I want to verify that `commit('isLoading', payload)` is executed. Here the payload is not the payload of the testAction helper (in my case 42) but the second argument of `commit`. That might be `false` and in my case it is. If I change the payload of the last expected commit to be `true` no assertion error is raised. The fix is to make the if condition in the mocked commit method more specific.