### PR TITLE
Makes the document more stable by removing stage-x for object separate syntax while it can be changed in the future

### DIFF
--- a/docs/guide/mutations.md
+++ b/docs/guide/mutations.md
@@ -86,7 +86,7 @@ Since a Vuex store's state is made reactive by Vue, when we mutate the state, Vu
 
   - Use `Vue.set(obj, 'newProp', 123)`, or
 
-  - Replace that Object with a fresh one. For example, using the stage-3 [object spread syntax](https://github.com/sebmarkbage/ecmascript-rest-spread) we can write it like this:
+  - Replace that Object with a fresh one. For example, using the [object spread syntax](https://github.com/sebmarkbage/ecmascript-rest-spread) we can write it like this:
 
     ``` js
     state.obj = { ...state.obj, newProp: 123 }


### PR DESCRIPTION
The stage of [object spread syntax](https://github.com/sebmarkbage/ecmascript-rest-spread) has been changed to 4