### PR TITLE
Return original Action Promise instead of pipe after "catch" when registerAction

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -408,17 +408,19 @@ function registerAction (store, type, handler, local) {
       rootGetters: store.getters,
       rootState: store.state
     }, payload, cb)
+
     if (!isPromise(res)) {
       res = Promise.resolve(res)
     }
+
     if (store._devtoolHook) {
       return res.catch(err => {
         store._devtoolHook.emit('vuex:error', err)
         throw err
       })
-    } else {
-      return res
     }
+
+    return res
   })
 }
 

--- a/src/store.js
+++ b/src/store.js
@@ -414,9 +414,10 @@ function registerAction (store, type, handler, local) {
     }
 
     if (store._devtoolHook) {
-      return res.catch(err => {
+      // Instead of explicitly returns a catched promise
+      // We just subscribing to "catch" for this promise
+      res.catch(err => {
         store._devtoolHook.emit('vuex:error', err)
-        throw err
       })
     }
 


### PR DESCRIPTION
Hello everyone!

## Prerequisites
In my project, I do not use just a promise to do actions.
Simplified version looks like this:
```js
class CustomPromise {
  constructor({ promise }) {
    this.promise = promise.then(this.handleSuccess, this.handleError)
  }

  handleSuccess = () => {
    // ...
  }

  handleError = () => {
    // ...
  }

  handleCancel = () => {
    // ...
  }

  then = (success, error) => this.promise.then(success, error)

  catch = error => this.promise.catch(error)
}
```
When I wanted to explicitly work with my action promise I found that I got only PromiseValue instead of my `CustomPromise`.
I had a `vue extenstion` for Chrome (yes, I removed it to test and verify a bug).

## Finally
[This line](https://github.com/vuejs/vuex/blob/dev/src/store.js#L415) creates a promise chain that not only subscribes to `catch`. This line provides only promise value/error to userland code instead of an original promise.

## How to fix?
Developer tools may be a useful tool, but `Vuex` should not change itself behavior when Devtools are available.
This `catch` should **ONLY** subscribes to errors (creates a parallel pipe and **DO NOT THROW** an error inside).
A userland code also will catch an error.
