### PR TITLE
docs: fixed links to vm.$watch

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -169,7 +169,7 @@ const store = new Vuex.Store({ ...options })
 
 -  `watch(fn: Function, callback: Function, options?: Object): Function`
 
-  Reactively watch `fn`'s return value, and call the callback when the value changes. `fn` receives the store's state as the first argument, and getters as the second argument. Accepts an optional options object that takes the same options as [Vue's `vm.$watch` method](https://vuejs.org/v2/api/#watch).
+  Reactively watch `fn`'s return value, and call the callback when the value changes. `fn` receives the store's state as the first argument, and getters as the second argument. Accepts an optional options object that takes the same options as [Vue's `vm.$watch` method](https://vuejs.org/v2/api/#vm-watch).
 
   To stop watching, call the returned unwatch function.
 

--- a/docs/zh/api/README.md
+++ b/docs/zh/api/README.md
@@ -170,7 +170,7 @@ const store = new Vuex.Store({ ...options })
 
 - `watch(fn: Function, callback: Function, options?: Object): Function`
 
-  响应式地侦听 `fn` 的返回值，当值改变时调用回调函数。`fn` 接收 store 的 state 作为第一个参数，其 getter 作为第二个参数。最后接收一个可选的对象参数表示 Vue 的 [`vm.$watch`](https://cn.vuejs.org/v2/api/#watch) 方法的参数。
+  响应式地侦听 `fn` 的返回值，当值改变时调用回调函数。`fn` 接收 store 的 state 作为第一个参数，其 getter 作为第二个参数。最后接收一个可选的对象参数表示 Vue 的 [`vm.$watch`](https://cn.vuejs.org/v2/api/#vm-watch) 方法的参数。
 
   要停止侦听，调用此方法返回的函数即可停止侦听。
 


### PR DESCRIPTION
In ["API Reference" > "Vuex.Store Instance Methods" > "watch"](https://vuex.vuejs.org/api/#watch) section of the `en` docs, there is a link of "Vue's `vm.$watch` method" but linked to `watch` options. It should be https://vuejs.org/v2/api/#vm-watch if I don't misunderstand it.

I also fixed the `zh` docs. And the `ru` docs seems right. but other language docs seems not same to the latest `en` version. So I am not sure whether should be updated too.

Thanks.
