### PR TITLE
docs: add a description of providing store to Vue instance

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -32,7 +32,7 @@ const store = new Vuex.Store({
 })
 ```
 
-In order to have an access to `$store` property in your Vue components, you need to provide the created store to Vue instance:
+In order to have an access to `this.$store` property in your Vue components, you need to provide the created store to Vue instance. Vuex has a mechanism to "inject" the store into all child components from the root component with the `store` option
 
 ```js
 new Vue({
@@ -61,7 +61,7 @@ store.commit('increment')
 console.log(store.state.count) // -> 1
 ```
 
-Or, inside Vue component:
+However, this pattern causes the component to rely on the global store singleton. When using a module system, it requires importing the store in every component that uses store state, and also requires mocking when testing the component. With store provided into the root Vue instance, you will be able to use the following syntax:
 
 ```js
 methods: {

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -15,7 +15,10 @@ At the center of every Vuex application is the **store**. A "store" is basically
 After [installing](../installation.md) Vuex, let's create a store. It is pretty straightforward - just provide an initial state object, and some mutations:
 
 ``` js
-// Make sure to call Vue.use(Vuex) first if using a module system
+import Vue from 'vue'
+import Vuex from 'vuex'
+
+Vue.use(Vuex)
 
 const store = new Vuex.Store({
   state: {
@@ -29,12 +32,44 @@ const store = new Vuex.Store({
 })
 ```
 
+In order to have an access to `$store` property in your Vue components, you need to provide the created store to Vue instance:
+
+```js
+new Vue({
+  el: '#app',
+  store: store,
+})
+```
+
+:::tip
+If you're using ES6, you can also go for ES6 object property shorthand notation (it's used when object key has the same name as the variable passed-in as a property):
+
+```js
+new Vue({
+  el: '#app',
+  store
+})
+```
+:::
+
+
 Now, you can access the state object as `store.state`, and trigger a state change with the `store.commit` method:
 
 ``` js
 store.commit('increment')
 
 console.log(store.state.count) // -> 1
+```
+
+Or, inside Vue component:
+
+```js
+methods: {
+  increment() {
+    this.$store.commit('increment');
+    console.log(this.$store.state.count)
+  }
+}
 ```
 
 Again, the reason we are committing a mutation instead of changing `store.state.count` directly, is because we want to explicitly track it. This simple convention makes your intention more explicit, so that you can reason about state changes in your app better when reading the code. In addition, this gives us the opportunity to implement tools that can log every mutation, take state snapshots, or even perform time travel debugging.

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -32,9 +32,17 @@ const store = new Vuex.Store({
 })
 ```
 
-In order to have an access to `this.$store` property in your Vue components, you need to provide the created store to Vue instance. Vuex has a mechanism to "inject" the store into all child components from the root component with the `store` option
+Now, you can access the state object as `store.state`, and trigger a state change with the `store.commit` method:
 
-```js
+``` js
+store.commit('increment')
+
+console.log(store.state.count) // -> 1
+```
+
+In order to have an access to `this.$store` property in your Vue components, you need to provide the created store to Vue instance. Vuex has a mechanism to "inject" the store into all child components from the root component with the `store` option:
+
+``` js
 new Vue({
   el: '#app',
   store: store,
@@ -52,21 +60,12 @@ new Vue({
 ```
 :::
 
-
-Now, you can access the state object as `store.state`, and trigger a state change with the `store.commit` method:
+Now we can commit a mutation from component's method:
 
 ``` js
-store.commit('increment')
-
-console.log(store.state.count) // -> 1
-```
-
-However, this pattern causes the component to rely on the global store singleton. When using a module system, it requires importing the store in every component that uses store state, and also requires mocking when testing the component. With store provided into the root Vue instance, you will be able to use the following syntax:
-
-```js
 methods: {
   increment() {
-    this.$store.commit('increment');
+    this.$store.commit('increment')
     console.log(this.$store.state.count)
   }
 }


### PR DESCRIPTION
_Note:_ This change was already introduced in #858 and it's still crucial for Vuex docs but since this PR exists for 1.5 years and has conflicts with a base branch, I'm opening a new one.

Added a short description of how to provide a store to Vue instance to have access to it from inside Vue components.

**Update:** found docs on injecting store in the `State` doc. I still think they should be moved to `Getting started` part because it's just easier not to miss it in the entry doc.