### PR TITLE
doc: Enabling DocSearch

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -39,6 +39,10 @@ module.exports = {
   serviceWorker: true,
   theme: 'vue',
   themeConfig: {
+    algolia: {
+      apiKey: '97f135e4b5f5487fb53f0f2dae8db59d',
+      indexName: 'vuex',
+    },
     repo: 'vuejs/vuex',
     docsDir: 'docs',
     locales: {


### PR DESCRIPTION
👋 vuex,

I am [working on DocSearch](https://community.algolia.com/docsearch/), this PR will enable vuex to use the same search [experience as vuepress](https://vuepress.vuejs.org/theme/default-theme-config.html#algolia-search), [vuejs](https://vuejs.org/), [bootstrap](https://getbootstrap.com/docs/4.1/getting-started/introduction/) ...

Our scraper will run every 24H to update your Algolia index. Feel free to [PR your configuration](https://github.com/algolia/docsearch-configs/blob/0b171ddf626dac501b2d9bf4a80e79613c874918/configs/vuex.json) if you need any update, the search is out of the box.

Let us know if you need anything.