### PR TITLE
docs & examples: rewrite state object to functions everywhere

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -16,9 +16,9 @@ After [installing](../installation.md) Vuex, let's create a store. It is pretty 
 // Make sure to call Vue.use(Vuex) first if using a module system
 
 const store = new Vuex.Store({
-  state: {
+  state: () => ({
     count: 0
-  },
+  }),
   mutations: {
     increment (state) {
       state.count++

--- a/docs/guide/actions.md
+++ b/docs/guide/actions.md
@@ -9,9 +9,9 @@ Let's register a simple action:
 
 ``` js
 const store = new Vuex.Store({
-  state: {
+  state: () => ({
     count: 0
-  },
+  }),
   mutations: {
     increment (state) {
       state.count++

--- a/docs/guide/getters.md
+++ b/docs/guide/getters.md
@@ -18,12 +18,12 @@ Getters will receive the state as their 1st argument:
 
 ``` js
 const store = new Vuex.Store({
-  state: {
+  state: () => ({
     todos: [
       { id: 1, text: '...', done: true },
       { id: 2, text: '...', done: false }
     ]
-  },
+  }),
   getters: {
     doneTodos: state => {
       return state.todos.filter(todo => todo.done)

--- a/docs/guide/modules.md
+++ b/docs/guide/modules.md
@@ -6,14 +6,14 @@ To help with that, Vuex allows us to divide our store into **modules**. Each mod
 
 ``` js
 const moduleA = {
-  state: { ... },
+  state: () => ({ ... }),
   mutations: { ... },
   actions: { ... },
   getters: { ... }
 }
 
 const moduleB = {
-  state: { ... },
+  state: () => ({ ... }),
   mutations: { ... },
   actions: { ... }
 }
@@ -35,7 +35,7 @@ Inside a module's mutations and getters, the first argument received will be **t
 
 ``` js
 const moduleA = {
-  state: { count: 0 },
+  state: () => ({ count: 0 }),
   mutations: {
     increment (state) {
       // `state` is the local module state

--- a/docs/guide/mutations.md
+++ b/docs/guide/mutations.md
@@ -4,9 +4,9 @@ The only way to actually change state in a Vuex store is by committing a mutatio
 
 ``` js
 const store = new Vuex.Store({
-  state: {
+  state: () => ({
     count: 1
-  },
+  }),
   mutations: {
     increment (state) {
       // mutate state
@@ -107,7 +107,7 @@ import Vuex from 'vuex'
 import { SOME_MUTATION } from './mutation-types'
 
 const store = new Vuex.Store({
-  state: { ... },
+  state: () => ({ ... }),
   mutations: {
     // we can use the ES2015 computed property name feature
     // to use a constant as the function name

--- a/examples/chat/store/index.js
+++ b/examples/chat/store/index.js
@@ -7,7 +7,7 @@ import createLogger from '../../../src/plugins/logger'
 
 Vue.use(Vuex)
 
-const state = {
+const state = () => ({
   currentThreadID: null,
   threads: {
     /*
@@ -32,7 +32,7 @@ const state = {
     }
     */
   }
-}
+})
 
 export default new Vuex.Store({
   state,

--- a/examples/counter-hot/store/index.js
+++ b/examples/counter-hot/store/index.js
@@ -6,10 +6,10 @@ import * as mutations from './mutations'
 
 Vue.use(Vuex)
 
-const state = {
+const state = () => ({
   count: 0,
   history: []
-}
+})
 
 const store = new Vuex.Store({
   state,

--- a/examples/counter/store.js
+++ b/examples/counter/store.js
@@ -5,9 +5,9 @@ Vue.use(Vuex)
 
 // root state object.
 // each Vuex instance is just a single state tree.
-const state = {
+const state = () => ({
   count: 0
-}
+})
 
 // mutations are operations that actually mutates the state.
 // each mutation handler gets the entire state tree as the

--- a/examples/shopping-cart/store/modules/cart.js
+++ b/examples/shopping-cart/store/modules/cart.js
@@ -2,10 +2,10 @@ import shop from '../../api/shop'
 
 // initial state
 // shape: [{ id, quantity }]
-const state = {
+const state = () => ({
   items: [],
   checkoutStatus: null
-}
+})
 
 // getters
 const getters = {

--- a/examples/shopping-cart/store/modules/products.js
+++ b/examples/shopping-cart/store/modules/products.js
@@ -1,9 +1,9 @@
 import shop from '../../api/shop'
 
 // initial state
-const state = {
+const state = () => ({
   all: []
-}
+})
 
 // getters
 const getters = {}

--- a/examples/todomvc/store/index.js
+++ b/examples/todomvc/store/index.js
@@ -7,9 +7,9 @@ import plugins from './plugins'
 Vue.use(Vuex)
 
 export default new Vuex.Store({
-  state: {
+  state: () => ({
     todos: JSON.parse(window.localStorage.getItem(STORAGE_KEY) || '[]')
-  },
+  }),
   actions,
   mutations,
   plugins


### PR DESCRIPTION
## Overview
Rewrite state, object to function everywhere.

## Details
To avoid shared state on the server side, we should change our state from object to functions everywhere.

## Related Pages
[stack overflow](https://stackoverflow.com/questions/49557177/vuex-state-returned-as-function-or-object-literal)


If it is wrong, please close this pr:bow: