### PR TITLE
Fix: add `devtools` to StoreOptions interface

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -86,6 +86,7 @@ export interface StoreOptions<S> {
   modules?: ModuleTree<S>;
   plugins?: Plugin<S>[];
   strict?: boolean;
+  devtools?: boolean;
 }
 
 export type ActionHandler<S, R> = (this: Store<R>, injectee: ActionContext<S, R>, payload: any) => any;


### PR DESCRIPTION
Updates `StoreOptions` type to include the [`devtools`](https://vuex.vuejs.org/api/#devtools) option, resolving TypeScript error when option is included in store constructor.