### PR TITLE
docs: complement preserveState information

### DIFF
--- a/docs/guide/modules.md
+++ b/docs/guide/modules.md
@@ -295,7 +295,11 @@ Dynamic module registration makes it possible for other Vue plugins to also leve
 
 You can also remove a dynamically registered module with `store.unregisterModule(moduleName)`. Note you cannot remove static modules (declared at store creation) with this method.
 
+#### Preserving state
+
 It may be likely that you want to preserve the previous state when registering a new module, such as preserving state from a Server Side Rendered app. You can achieve this with `preserveState` option: `store.registerModule('a', module, { preserveState: true })`
+
+When you set `preserveState: true`, the module is registered, actions, mutations and getters are added to the store, but the state not. It's assumed that your store state already contains state for that module and you don't want to overwrite it.
 
 ### Module Reuse
 

--- a/docs/ptbr/guide/modules.md
+++ b/docs/ptbr/guide/modules.md
@@ -296,7 +296,11 @@ O registro de módulo dinâmico possibilita que outros plug-ins Vue aproveitem t
 
 Você também pode remover um módulo dinamicamente registrado com o `store.unregisterModule(moduleName)`. Note que você não pode remover módulos estáticos (declarados na criação do _store_) com este método.
 
+#### Preservando o estado
+
 É bem provável que você queira preservar o estado anterior ao registrar um novo módulo, como preservar o estado de um aplicativo Renderizado no Lado do Servidor (_Server_ _Side_ _Rendered_). Você pode fazer isso com a opção `preserveState`:`store.registerModule('a', module, {preserveState: true})`
+
+Quando você informa `preserveState: true`, o módulo é registrado, as ações, mutações e _getters_ são incluídos no _store_, mas o estado não. É assumido que estado da sua _store_ já contém um estado para aquele módulo e você não quer sobrescrevê-lo.
 
 ### Reutilização do Módulo
 


### PR DESCRIPTION
It is not very clear the purpose of `preserveState` option in the docs. 

[This comment](https://github.com/vuejs/vuex/issues/1130#issuecomment-356612119) clarified the behavior, so I included in a dedicated `preserveState` subsection.