### PR TITLE
support jsdelivr npm cdn like vue package does

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/vuex.common.js",
   "module": "dist/vuex.esm.js",
   "unpkg": "dist/vuex.js",
+  "jsdelivr": "dist/vuex.js",
   "typings": "types/index.d.ts",
   "files": [
     "dist",


### PR DESCRIPTION
see difference here:

- https://cdn.jsdelivr.net/npm/vue/package.json
- https://cdn.jsdelivr.net/npm/vuex/package.json