### PR TITLE
Make mutation and action payload optional in definition file

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -97,7 +97,7 @@ export interface StoreOptions<S> {
   strict?: boolean;
 }
 
-export type ActionHandler<S, R> = (this: Store<R>, injectee: ActionContext<S, R>, payload: any) => any;
+export type ActionHandler<S, R> = (this: Store<R>, injectee: ActionContext<S, R>, payload?: any) => any;
 export interface ActionObject<S, R> {
   root?: boolean;
   handler: ActionHandler<S, R>;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -105,7 +105,7 @@ export interface ActionObject<S, R> {
 
 export type Getter<S, R> = (state: S, getters: any, rootState: R, rootGetters: any) => any;
 export type Action<S, R> = ActionHandler<S, R> | ActionObject<S, R>;
-export type Mutation<S> = (state: S, payload: any) => any;
+export type Mutation<S> = (state: S, payload?: any) => any;
 export type Plugin<S> = (store: Store<S>) => any;
 
 export interface Module<S, R> {


### PR DESCRIPTION
When testing a mutation without payload in TypeScript, it complains that about the missing payload, even though it's not mandatory.

This PR simply makes the payload optional.

Fixes #1491