### PR TITLE
docs(en) Small phrase improvement: silly

### DIFF
--- a/docs/guide/actions.md
+++ b/docs/guide/actions.md
@@ -47,7 +47,7 @@ Actions are triggered with the `store.dispatch` method:
 store.dispatch('increment')
 ```
 
-This may look dumb at first sight: if we want to increment the count, why don't we just call `store.commit('increment')` directly? Remember that **mutations have to be synchronous**? Actions don't. We can perform **asynchronous** operations inside an action:
+This may look silly at first sight: if we want to increment the count, why don't we just call `store.commit('increment')` directly? Remember that **mutations have to be synchronous**? Actions don't. We can perform **asynchronous** operations inside an action:
 
 ``` js
 actions: {


### PR DESCRIPTION
Replace "dumb" with "silly", since dumb [is defined as mute or unable to speak](https://www.dictionary.com/browse/dumb). What the implies is this function call may seem to be a bit extra and non obvious at first glance. 

The whimsical word "silly" is a nice stand in for this.

![](https://media0.giphy.com/media/ujzJFRYbyjZe0/giphy.gif)