### PR TITLE
Genericity for mutations and actions.

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,19 +7,19 @@ import { mapState, mapMutations, mapGetters, mapActions, createNamespacedHelpers
 
 export * from "./helpers";
 
-export declare class Store<S> {
-  constructor(options: StoreOptions<S>);
+export declare class Store<S, M extends MutationTree<S> = MutationTree<S>, A extends ActionTree<S, S> = ActionTree<S, S>> {
+  constructor(options: StoreOptions<S, M, A>);
 
   readonly state: S;
   readonly getters: any;
 
   replaceState(state: S): void;
 
-  dispatch: Dispatch;
-  commit: Commit;
+  dispatch: Dispatch<A>;
+  commit: Commit<M>;
 
-  subscribe<P extends MutationPayload>(fn: (mutation: P, state: S) => any): () => void;
-  subscribeAction<P extends ActionPayload>(fn: SubscribeActionOptions<P, S>): () => void;
+  subscribe<P extends MutationPayload<M>>(fn: (mutation: P, state: S) => any): () => void;
+  subscribeAction<P extends ActionPayload<A>>(fn: SubscribeActionOptions<P, S>): () => void;
   watch<T>(getter: (state: S, getters: any) => T, cb: (value: T, oldValue: T) => void, options?: WatchOptions): () => void;
 
   registerModule<T>(path: string, module: Module<T, S>, options?: ModuleOptions): void;
@@ -28,44 +28,43 @@ export declare class Store<S> {
   unregisterModule(path: string): void;
   unregisterModule(path: string[]): void;
 
-  hotUpdate(options: {
-    actions?: ActionTree<S, S>;
-    mutations?: MutationTree<S>;
+  hotUpdate<M, A>(options: {
+    actions?: A;
+    mutations?: M;
     getters?: GetterTree<S, S>;
     modules?: ModuleTree<S>;
   }): void;
 }
 
 export declare function install(Vue: typeof _Vue): void;
-
-export interface Dispatch {
-  (type: string, payload?: any, options?: DispatchOptions): Promise<any>;
-  <P extends Payload>(payloadWithType: P, options?: DispatchOptions): Promise<any>;
+export interface Dispatch<A> {
+  (type: keyof A, payload?: any, options?: DispatchOptions): Promise<any>;
+  <P extends Payload<A>>(payloadWithType: P, options?: DispatchOptions): Promise<any>;
 }
 
-export interface Commit {
-  (type: string, payload?: any, options?: CommitOptions): void;
-  <P extends Payload>(payloadWithType: P, options?: CommitOptions): void;
+export interface Commit<M> {
+  (type: keyof M, payload?: any, options?: CommitOptions): void;
+  <P extends Payload<M>>(payloadWithType: P, options?: CommitOptions): void;
 }
 
-export interface ActionContext<S, R> {
-  dispatch: Dispatch;
-  commit: Commit;
+export interface ActionContext<S, R, M extends MutationTree<S> = MutationTree<S>, A extends ActionTree<S, R> = ActionTree<S, R>> {
+  dispatch: Dispatch<A>;
+  commit: Commit<M>;
   state: S;
   getters: any;
   rootState: R;
   rootGetters: any;
 }
 
-export interface Payload {
-  type: string;
+export interface Payload<T> {
+  type: keyof T;
 }
 
-export interface MutationPayload extends Payload {
+export interface MutationPayload<M> extends Payload<M> {
   payload: any;
 }
 
-export interface ActionPayload extends Payload {
+export interface ActionPayload<A> extends Payload<A> {
   payload: any;
 }
 
@@ -87,16 +86,15 @@ export interface CommitOptions {
   root?: boolean;
 }
 
-export interface StoreOptions<S> {
+export interface StoreOptions<S, M, A> {
   state?: S | (() => S);
   getters?: GetterTree<S, S>;
-  actions?: ActionTree<S, S>;
-  mutations?: MutationTree<S>;
+  actions?: A;
+  mutations?: M;
   modules?: ModuleTree<S>;
   plugins?: Plugin<S>[];
   strict?: boolean;
 }
-
 export type ActionHandler<S, R> = (this: Store<R>, injectee: ActionContext<S, R>, payload?: any) => any;
 export interface ActionObject<S, R> {
   root?: boolean;
@@ -108,12 +106,12 @@ export type Action<S, R> = ActionHandler<S, R> | ActionObject<S, R>;
 export type Mutation<S> = (state: S, payload?: any) => any;
 export type Plugin<S> = (store: Store<S>) => any;
 
-export interface Module<S, R> {
+export interface Module<S, R, M extends MutationTree<S> = MutationTree<S>, A extends ActionTree<S, S> = ActionTree<S, S>> {
   namespaced?: boolean;
   state?: S | (() => S);
   getters?: GetterTree<S, R>;
-  actions?: ActionTree<S, R>;
-  mutations?: MutationTree<S>;
+  actions?: A;
+  mutations?: M;
   modules?: ModuleTree<R>;
 }
 

--- a/types/test/index.ts
+++ b/types/test/index.ts
@@ -3,20 +3,31 @@ import * as Vuex from "../index";
 import createLogger from "../../dist/logger";
 
 Vue.use(Vuex);
-
+const state = {
+  value: 0
+};
+const mutations = {
+  setValue(s: typeof state, val: number) {
+    s.value = val;
+  },
+};
 namespace StoreInstance {
   const store = new Vuex.Store({
-    state: {
-      value: 0
-    }
+    state,
+    mutations,
+    actions: {
+      updateValue(ctx, payload) {
+        ctx.commit('setValue', payload);
+      },
+    },
   });
-
   store.state.value;
   store.getters.foo;
-
+  store.dispatch('updateValue', 1);
+  store.commit('setValue', 2);
   store.dispatch("foo", { amount: 1 }).then(() => {});
   store.dispatch({
-    type: "foo",
+    type: 'foo',
     amount: 1
   }).then(() => {});
 


### PR DESCRIPTION
Add genericity for mutations and actions to hint the commit and dispatch methods.