### PR TITLE
add warnings when the different namespaced modules has the same names…

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -306,7 +306,6 @@ function installModule (store, rootState, path, module, hot) {
       if (process.env.NODE_ENV !== 'production') {
         console.error(`[vuex] duplicate namespace ${namespace} for the namespaced module ${path.join('/')}`)
       }
-      return
     }
     store._modulesNamespaceMap[namespace] = module
   }

--- a/src/store.js
+++ b/src/store.js
@@ -301,11 +301,8 @@ function installModule (store, rootState, path, module, hot) {
 
   // register in namespace map
   if (module.namespaced) {
-    const existedModule = store._modulesNamespaceMap[namespace]
-    if (existedModule) {
-      if (process.env.NODE_ENV !== 'production') {
-        console.error(`[vuex] duplicate namespace ${namespace} for the namespaced module ${path.join('/')}`)
-      }
+    if (store._modulesNamespaceMap[namespace] && process.env.NODE_ENV !== 'production') {
+      console.error(`[vuex] duplicate namespace ${namespace} for the namespaced module ${path.join('/')}`)
     }
     store._modulesNamespaceMap[namespace] = module
   }

--- a/src/store.js
+++ b/src/store.js
@@ -301,6 +301,13 @@ function installModule (store, rootState, path, module, hot) {
 
   // register in namespace map
   if (module.namespaced) {
+    const existedModule = store._modulesNamespaceMap[namespace]
+    if (existedModule) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.error(`[vuex] duplicate namespace ${namespace} for the namespaced module ${path.join('/')}`)
+      }
+      return
+    }
     store._modulesNamespaceMap[namespace] = module
   }
 


### PR DESCRIPTION
Add warnings when the different namespaced modules has the same namespace.
There is a situation that different namespaced modules could have the same namespace, so when in the method of installModule, generate store._modulesNamespaceMap, the follow module will override the before module.
For example:
```
new Store({
  modules: {
    m1: {
      namespaced: true,
      state: {
        a: "a1"
      }
    },
    m2: {
      modules: {
        m1: {
          namespaced: true,
          state: {
            a: "a2"
          }
        }
      }
    }
  }
})
```
the module m1 has the namespace 'm1',
the module m2/m1 has the same namespace 'm1'
so in the store._modulesNamespaceMap the module m2/m1 will override the module m1