### PR TITLE
Typescript: Use generics for payload/result in commit/dispatch

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -39,12 +39,12 @@ export declare class Store<S> {
 export declare function install(Vue: typeof _Vue): void;
 
 export interface Dispatch {
-  (type: string, payload?: any, options?: DispatchOptions): Promise<any>;
-  <P extends Payload>(payloadWithType: P, options?: DispatchOptions): Promise<any>;
+  <P = any, R = any>(type: string, payload?: P, options?: DispatchOptions): Promise<R>;
+  <P extends Payload, R = any>(payloadWithType: P, options?: DispatchOptions): Promise<R>;
 }
 
 export interface Commit {
-  (type: string, payload?: any, options?: CommitOptions): void;
+  <P = any>(type: string, payload?: P, options?: CommitOptions): void;
   <P extends Payload>(payloadWithType: P, options?: CommitOptions): void;
 }
 

--- a/types/test/index.ts
+++ b/types/test/index.ts
@@ -15,12 +15,15 @@ namespace StoreInstance {
   store.getters.foo;
 
   store.dispatch("foo", { amount: 1 }).then(() => {});
+  store.dispatch<{amount: number}>("foo", { amount: 1 }).then(() => {})
+  store.dispatch<{amount: number}, string>("foo", { amount: 1 }).then((value) => {})
   store.dispatch({
     type: "foo",
     amount: 1
   }).then(() => {});
 
   store.commit("foo", { amount: 1 });
+  store.commit<{amount: number}>("foo", { amount: 1 })
   store.commit({
     type: "foo",
     amount: 1


### PR DESCRIPTION
I am using Typescript to write my store, like this for example:
```typescript
interface State {
    counter: number;
}

interface AddToCounterPayload {
    amount: number;
}

interface SubstractFromCounterPayload {
    amount: number;
}

type SubstractFromCounterResult = number

const store = new Store<State>({
    mutations: {
        addToCounter: (state, payload: AddToCounterPayload): void => {
            state.counter += payload.amount;
        }
    },
    actions: {
        substractFromCounter: async (context, payload: SubstractFromCounterPayload): Promise<SubstractFromCounterResult> => {
            const addToCounterPayload: AddToCounterPayload =  {amount: -1 * payload.amount};
            context.commit('addToCounter', addToCounterPayload)
            return context.state.counter;
        }
    },
    state: {
        counter: 0
    }
})
```

Triggering a mutation like this will currently not check if the payload has the correct type
```typescript
// correct payload type
store.commit('addToCounter', {amount: 1});
// incorrect payload type
store.commit('addToCounter', {amount: '1'});
// Current solution to ensure correct type
const payload: AddToCounterPayload = {
  amount: 1
}
store.commit('addToCounter', payload);
```
But there are cases where I would prefer to build the payload inline, that's why I would like to propose using generics to set the payload type:
```typescript
store.commit<AddToCounterPayload>('addToCounter', {amount: 1});
```

Triggering actions would work similary but additionaly the type of the returned value can be set using the second generic parameter
```typescript
const result = store.dispatch<SubstractFromCounterPayload, SubstractFromCounterResult>('substractFromCounter', {amount: 1}); 
// type of result will be Promise<SubstractFromCounterResult>
```
By setting the default values of the generics to `any` the behavior of `commit` and `dispatch` won't change if called without generics.