### PR TITLE
Refactor: extract a method for duplicate environment judgement

### DIFF
--- a/examples/chat/store/index.js
+++ b/examples/chat/store/index.js
@@ -4,6 +4,7 @@ import * as getters from './getters'
 import * as actions from './actions'
 import mutations from './mutations'
 import createLogger from '../../../src/plugins/logger'
+import { isProdEnv } from '../../../src/util'
 
 Vue.use(Vuex)
 
@@ -39,7 +40,7 @@ export default new Vuex.Store({
   getters,
   actions,
   mutations,
-  plugins: process.env.NODE_ENV !== 'production'
+  plugins: !isProdEnv()
     ? [createLogger()]
     : []
 })

--- a/examples/shopping-cart/store/index.js
+++ b/examples/shopping-cart/store/index.js
@@ -3,16 +3,15 @@ import Vuex from 'vuex'
 import cart from './modules/cart'
 import products from './modules/products'
 import createLogger from '../../../src/plugins/logger'
+import { isProdEnv } from '../../../src/util'
 
 Vue.use(Vuex)
-
-const debug = process.env.NODE_ENV !== 'production'
 
 export default new Vuex.Store({
   modules: {
     cart,
     products
   },
-  strict: debug,
+  strict: !isProdEnv(),
   plugins: debug ? [createLogger()] : []
 })

--- a/examples/todomvc/store/plugins.js
+++ b/examples/todomvc/store/plugins.js
@@ -1,5 +1,6 @@
 import { STORAGE_KEY } from './mutations'
 import createLogger from '../../../src/plugins/logger'
+import { isProdEnv } from '../../../src/util'
 
 const localStoragePlugin = store => {
   store.subscribe((mutation, { todos }) => {
@@ -7,6 +8,6 @@ const localStoragePlugin = store => {
   })
 }
 
-export default process.env.NODE_ENV !== 'production'
+export default !isProdEnv()
   ? [createLogger(), localStoragePlugin]
   : [localStoragePlugin]

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,3 +1,4 @@
+import { isProdEnv } from './util'
 /**
  * Reduce the code which written in Vue.js for getting the state.
  * @param {String} [namespace] - Module's namespace
@@ -70,7 +71,7 @@ export const mapGetters = normalizeNamespace((namespace, getters) => {
       if (namespace && !getModuleByNamespace(this.$store, 'mapGetters', namespace)) {
         return
       }
-      if (process.env.NODE_ENV !== 'production' && !(val in this.$store.getters)) {
+      if (!isProdEnv() && !(val in this.$store.getters)) {
         console.error(`[vuex] unknown getter: ${val}`)
         return
       }
@@ -160,7 +161,7 @@ function normalizeNamespace (fn) {
  */
 function getModuleByNamespace (store, helper, namespace) {
   const module = store._modulesNamespaceMap[namespace]
-  if (process.env.NODE_ENV !== 'production' && !module) {
+  if (!isProdEnv() && !module) {
     console.error(`[vuex] module namespace not found in ${helper}(): ${namespace}`)
   }
   return module

--- a/src/module/module-collection.js
+++ b/src/module/module-collection.js
@@ -1,5 +1,5 @@
 import Module from './module'
-import { assert, forEachValue } from '../util'
+import { assert, forEachValue, isProdEnv } from '../util'
 
 export default class ModuleCollection {
   constructor (rawRootModule) {
@@ -26,7 +26,7 @@ export default class ModuleCollection {
   }
 
   register (path, rawModule, runtime = true) {
-    if (process.env.NODE_ENV !== 'production') {
+    if (!isProdEnv()) {
       assertRawModule(path, rawModule)
     }
 
@@ -56,7 +56,7 @@ export default class ModuleCollection {
 }
 
 function update (path, targetModule, newModule) {
-  if (process.env.NODE_ENV !== 'production') {
+  if (!isProdEnv()) {
     assertRawModule(path, newModule)
   }
 
@@ -67,7 +67,7 @@ function update (path, targetModule, newModule) {
   if (newModule.modules) {
     for (const key in newModule.modules) {
       if (!targetModule.getChild(key)) {
-        if (process.env.NODE_ENV !== 'production') {
+        if (!isProdEnv()) {
           console.warn(
             `[vuex] trying to add a new module '${key}' on hot reloading, ` +
             'manual reload is needed'

--- a/src/store.js
+++ b/src/store.js
@@ -1,7 +1,7 @@
 import applyMixin from './mixin'
 import devtoolPlugin from './plugins/devtool'
 import ModuleCollection from './module/module-collection'
-import { forEachValue, isObject, isPromise, assert, partial } from './util'
+import { forEachValue, isObject, isPromise, isProdEnv, assert, partial } from './util'
 
 let Vue // bind on install
 
@@ -14,7 +14,7 @@ export class Store {
       install(window.Vue)
     }
 
-    if (process.env.NODE_ENV !== 'production') {
+    if (!isProdEnv()) {
       assert(Vue, `must call Vue.use(Vuex) before creating a store instance.`)
       assert(typeof Promise !== 'undefined', `vuex requires a Promise polyfill in this browser.`)
       assert(this instanceof Store, `store must be called with the new operator.`)
@@ -74,7 +74,7 @@ export class Store {
   }
 
   set state (v) {
-    if (process.env.NODE_ENV !== 'production') {
+    if (!isProdEnv()) {
       assert(false, `use store.replaceState() to explicit replace store state.`)
     }
   }
@@ -90,7 +90,7 @@ export class Store {
     const mutation = { type, payload }
     const entry = this._mutations[type]
     if (!entry) {
-      if (process.env.NODE_ENV !== 'production') {
+      if (!isProdEnv()) {
         console.error(`[vuex] unknown mutation type: ${type}`)
       }
       return
@@ -103,7 +103,7 @@ export class Store {
     this._subscribers.forEach(sub => sub(mutation, this.state))
 
     if (
-      process.env.NODE_ENV !== 'production' &&
+      !isProdEnv() &&
       options && options.silent
     ) {
       console.warn(
@@ -123,7 +123,7 @@ export class Store {
     const action = { type, payload }
     const entry = this._actions[type]
     if (!entry) {
-      if (process.env.NODE_ENV !== 'production') {
+      if (!isProdEnv()) {
         console.error(`[vuex] unknown action type: ${type}`)
       }
       return
@@ -134,7 +134,7 @@ export class Store {
         .filter(sub => sub.before)
         .forEach(sub => sub.before(action, this.state))
     } catch (e) {
-      if (process.env.NODE_ENV !== 'production') {
+      if (!isProdEnv()) {
         console.warn(`[vuex] error in before action subscribers: `)
         console.error(e)
       }
@@ -150,7 +150,7 @@ export class Store {
           .filter(sub => sub.after)
           .forEach(sub => sub.after(action, this.state))
       } catch (e) {
-        if (process.env.NODE_ENV !== 'production') {
+        if (!isProdEnv()) {
           console.warn(`[vuex] error in after action subscribers: `)
           console.error(e)
         }
@@ -169,7 +169,7 @@ export class Store {
   }
 
   watch (getter, cb, options) {
-    if (process.env.NODE_ENV !== 'production') {
+    if (!isProdEnv()) {
       assert(typeof getter === 'function', `store.watch only accepts a function.`)
     }
     return this._watcherVM.$watch(() => getter(this.state, this.getters), cb, options)
@@ -184,7 +184,7 @@ export class Store {
   registerModule (path, rawModule, options = {}) {
     if (typeof path === 'string') path = [path]
 
-    if (process.env.NODE_ENV !== 'production') {
+    if (!isProdEnv()) {
       assert(Array.isArray(path), `module path must be a string or an Array.`)
       assert(path.length > 0, 'cannot register the root module by using registerModule.')
     }
@@ -198,7 +198,7 @@ export class Store {
   unregisterModule (path) {
     if (typeof path === 'string') path = [path]
 
-    if (process.env.NODE_ENV !== 'production') {
+    if (!isProdEnv()) {
       assert(Array.isArray(path), `module path must be a string or an Array.`)
     }
 
@@ -301,7 +301,7 @@ function installModule (store, rootState, path, module, hot) {
 
   // register in namespace map
   if (module.namespaced) {
-    if (store._modulesNamespaceMap[namespace] && process.env.NODE_ENV !== 'production') {
+    if (store._modulesNamespaceMap[namespace] && !isProdEnv()) {
       console.error(`[vuex] duplicate namespace ${namespace} for the namespaced module ${path.join('/')}`)
     }
     store._modulesNamespaceMap[namespace] = module
@@ -354,7 +354,7 @@ function makeLocalContext (store, namespace, path) {
 
       if (!options || !options.root) {
         type = namespace + type
-        if (process.env.NODE_ENV !== 'production' && !store._actions[type]) {
+        if (!isProdEnv() && !store._actions[type]) {
           console.error(`[vuex] unknown local action type: ${args.type}, global type: ${type}`)
           return
         }
@@ -370,7 +370,7 @@ function makeLocalContext (store, namespace, path) {
 
       if (!options || !options.root) {
         type = namespace + type
-        if (process.env.NODE_ENV !== 'production' && !store._mutations[type]) {
+        if (!isProdEnv() && !store._mutations[type]) {
           console.error(`[vuex] unknown local mutation type: ${args.type}, global type: ${type}`)
           return
         }
@@ -453,7 +453,7 @@ function registerAction (store, type, handler, local) {
 
 function registerGetter (store, type, rawGetter, local) {
   if (store._wrappedGetters[type]) {
-    if (process.env.NODE_ENV !== 'production') {
+    if (!isProdEnv()) {
       console.error(`[vuex] duplicate getter key: ${type}`)
     }
     return
@@ -470,7 +470,7 @@ function registerGetter (store, type, rawGetter, local) {
 
 function enableStrictMode (store) {
   store._vm.$watch(function () { return this._data.$$state }, () => {
-    if (process.env.NODE_ENV !== 'production') {
+    if (!isProdEnv()) {
       assert(store._committing, `do not mutate vuex store state outside mutation handlers.`)
     }
   }, { deep: true, sync: true })
@@ -489,7 +489,7 @@ function unifyObjectStyle (type, payload, options) {
     type = type.type
   }
 
-  if (process.env.NODE_ENV !== 'production') {
+  if (!isProdEnv()) {
     assert(typeof type === 'string', `expects string as the type, but found ${typeof type}.`)
   }
 
@@ -498,7 +498,7 @@ function unifyObjectStyle (type, payload, options) {
 
 export function install (_Vue) {
   if (Vue && _Vue === Vue) {
-    if (process.env.NODE_ENV !== 'production') {
+    if (!isProdEnv()) {
       console.error(
         '[vuex] already installed. Vue.use(Vuex) should be called only once.'
       )

--- a/src/util.js
+++ b/src/util.js
@@ -70,3 +70,7 @@ export function partial (fn, arg) {
     return fn(arg)
   }
 }
+
+export function isProdEnv () {
+  return process.env.NODE_ENV === 'production'
+}


### PR DESCRIPTION
There are 17 times of environment judgement in `store.js`.  Extract it to  `util.js`