### PR TITLE
fix(docs): Clearify state object type

### DIFF
--- a/docs/guide/state.md
+++ b/docs/guide/state.md
@@ -8,6 +8,8 @@ Vuex uses a **single state tree** - that is, this single object contains all you
 
 The single state tree does not conflict with modularity - in later chapters we will discuss how to split your state and mutations into sub modules.
 
+The data you store in Vuex follows the same rules as the `data` in a Vue instance, ie the state object must be plain. **See also:** [Vue#data](https://vuejs.org/v2/api/#data).
+
 ### Getting Vuex State into Vue Components
 
 So how do we display state inside the store in our Vue components? Since Vuex stores are reactive, the simplest way to "retrieve" state from it is simply returning some store state from within a [computed property](https://vuejs.org/guide/computed.html):

--- a/docs/ptbr/guide/state.md
+++ b/docs/ptbr/guide/state.md
@@ -8,6 +8,8 @@ O Vuex usa uma **árvore única de estado** - ou seja, esse único objeto conté
 
 A árvore única de estado não entra em conflito com a modularidade - em capítulos posteriores, discutiremos como dividir seu estado e mutações em sub-módulos.
 
+O tipo de dados guardados no Vuex segue as mesmas regras que `data` em instâncias Vue, ou seja o _state_ têm de ser um objeto simples. [Detalhes](https://br.vuejs.org/v2/api/index.html#data)
+
 ### Obtendo o Estado Vuex nos Componentes Vue
 
 Então, como exibimos o estado dentro do _store_ em nossos componentes Vue? Uma vez que os _stores_ Vuex são reativos, a maneira mais simples de "recuperar" o estado é simplesmente retornar algum estado do _store_ dentro de um [dado computado](https://br.vuejs.org/v2/guide/computed.html):


### PR DESCRIPTION
Clearify in the docs that Vuex state object should be a plain object that follows the same rules as `data` in a Vue instance. This addition will clarify what is "good practise" to use in Vuex.

closes #1587 
closes https://github.com/vuejs/vue/pull/10379