### PR TITLE
Add warning when setting state of a non-existent state property name 

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -270,9 +270,29 @@ function resetStoreVM (store, state, hot) {
   // some funky global mixins
   const silent = Vue.config.silent
   Vue.config.silent = true
+
+  let $$state = state
+
+  if (process.env.NODE_ENV !== 'production') {
+    $$state = new Proxy($$state, {
+      set: function (obj, prop, val) {
+        if (!obj.hasOwnProperty(prop)) {
+          console.error(`[vuex] state: The property '${prop}' must be defined in the state object.`)
+        }
+
+        let updated = true
+        try {
+          obj[prop] = val
+        } catch (e) {
+          updated = false
+        }
+        return updated
+      }
+    })
+  }
   store._vm = new Vue({
     data: {
-      $$state: state
+      $$state: $$state
     },
     computed
   })

--- a/test/unit/store.spec.js
+++ b/test/unit/store.spec.js
@@ -270,6 +270,27 @@ describe('Store', () => {
     }).toThrowError(/store must be called with the new operator/)
   })
 
+  it('asserts we do not set state in non previously declared state properties', () => {
+    spyOn(console, 'error')
+
+    const PROP = 'foo'
+    const store = new Vuex.Store({
+      strict: true,
+      state: () => ({/* forgot to declare "PROP" */}),
+      mutations: {
+        [PROP] (state, payload) {
+          state[PROP] = payload
+        }
+      }
+    })
+    expect(typeof store.state[PROP]).toBe('undefined')
+    store.commit(PROP, 5)
+    expect(console.error).toHaveBeenCalledWith(
+      `[vuex] state: The property '${PROP}' must be defined in the state object.`
+    )
+    expect(store.state[PROP]).toBe(5)
+  })
+
   it('should accept state as function', () => {
     const store = new Vuex.Store({
       state: () => ({

--- a/test/unit/store.spec.js
+++ b/test/unit/store.spec.js
@@ -287,11 +287,14 @@ describe('Store', () => {
   })
 
   it('should not call root state function twice', () => {
-    const spy = jasmine.createSpy().and.returnValue(1)
+    const secondSpy = jasmine.createSpy()
+    const firstSpy = jasmine.createSpy().and.returnValue(secondSpy)
+
     new Vuex.Store({
-      state: spy
+      state: firstSpy
     })
-    expect(spy).toHaveBeenCalledTimes(1)
+    expect(firstSpy).toHaveBeenCalledTimes(1)
+    expect(secondSpy).not.toHaveBeenCalled()
   })
 
   it('subscribe: should handle subscriptions / unsubscriptions', () => {


### PR DESCRIPTION
This PR add the possibility to be warned in development for the problem described in 1120.
It adds a unit test for that scenario.

While testing this I found out another unit test that needed adjustment and did that in a separate commit. 

Fixes #1120