### PR TITLE
webpack preset useBuiltIns usage toast promise error

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -20,7 +20,7 @@ export class Store {
       // and set babel presets property useBuiltIns is 'usage'
       // then the polyfill will be loaded when Promise used
       // so this way has a bug when we webpack,if we use vuex without used Promise,always show this error
-      //assert(typeof Promise !== 'undefined', `vuex requires a Promise polyfill in this browser.`)
+      // assert(typeof Promise !== 'undefined', `vuex requires a Promise polyfill in this browser.`)
       try {
         new Promise(() => {});
       } catch (error) {

--- a/src/store.js
+++ b/src/store.js
@@ -22,7 +22,7 @@ export class Store {
       // so this way has a bug when we webpack,if we use vuex without used Promise,always show this error
       //assert(typeof Promise !== 'undefined', `vuex requires a Promise polyfill in this browser.`)
       try {
-        let tempPromise = new Promise();
+        let tempPromise = new Promise(() => {});
         tempPromise = null;
       } catch (error) {
         assert(false, `vuex requires a Promise polyfill in this browser.`)

--- a/src/store.js
+++ b/src/store.js
@@ -16,7 +16,17 @@ export class Store {
 
     if (process.env.NODE_ENV !== 'production') {
       assert(Vue, `must call Vue.use(Vuex) before creating a store instance.`)
-      assert(typeof Promise !== 'undefined', `vuex requires a Promise polyfill in this browser.`)
+      // when we use webpack,
+      // and set babel presets property useBuiltIns is 'usage'
+      // then the polyfill will be loaded when Promise used
+      // so this way has a bug when we webpack,if we use vuex without used Promise,always show this error
+      //assert(typeof Promise !== 'undefined', `vuex requires a Promise polyfill in this browser.`)
+      try {
+        let tempPromise = new Promise();
+        tempPromise = null;
+      } catch (error) {
+        assert(false, `vuex requires a Promise polyfill in this browser.`)
+      }
       assert(this instanceof Store, `store must be called with the new operator.`)
     }
 

--- a/src/store.js
+++ b/src/store.js
@@ -22,8 +22,7 @@ export class Store {
       // so this way has a bug when we webpack,if we use vuex without used Promise,always show this error
       //assert(typeof Promise !== 'undefined', `vuex requires a Promise polyfill in this browser.`)
       try {
-        let tempPromise = new Promise(() => {});
-        tempPromise = null;
+        new Promise(() => {});
       } catch (error) {
         assert(false, `vuex requires a Promise polyfill in this browser.`)
       }

--- a/src/store.js
+++ b/src/store.js
@@ -22,7 +22,7 @@ export class Store {
       // so this way has a bug when we webpack,if we use vuex without used Promise,always show this error
       // assert(typeof Promise !== 'undefined', `vuex requires a Promise polyfill in this browser.`)
       try {
-        new Promise(() => {});
+        new Promise(() => {})
       } catch (error) {
         assert(false, `vuex requires a Promise polyfill in this browser.`)
       }


### PR DESCRIPTION
when we use webpack,
and set babel presets property useBuiltIns is 'usage'
then the polyfill will be loaded when Promise used
so this way has a bug when we webpack,if we use vuex without used Promise,always show the error: vuex requires a Promise polyfill in this browser.

so I have change the validate Promise way to:

```js
try {
  new Promise(() => {})
} catch (error) {
  assert(false, `vuex requires a Promise polyfill in this browser.`)
}
```