### PR TITLE
action subscribers would receive a call even when the action failed

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -148,7 +148,7 @@ export class Store {
       try {
         this._actionSubscribers
           .filter(sub => sub.after)
-          .forEach(sub => sub.after(action, this.state))
+          .forEach(sub => sub.after(action, this.state, /*isError:*/false, res))
       } catch (e) {
         if (process.env.NODE_ENV !== 'production') {
           console.warn(`[vuex] error in after action subscribers: `)
@@ -156,6 +156,19 @@ export class Store {
         }
       }
       return res
+    })
+    .catch(errorResult => {
+      try {
+        this._actionSubscribers
+          .filter(sub => sub.after)
+          .forEach(sub => sub.after(action, this.state, /*isError:*/true, errorResult))
+      } catch (e) {
+        if (process.env.NODE_ENV !== 'production') {
+          console.warn(`[vuex] error in after action subscribers: `)
+          console.error(e)
+        }
+      }
+      throw errorResult
     })
   }
 

--- a/src/store.js
+++ b/src/store.js
@@ -148,7 +148,7 @@ export class Store {
       try {
         this._actionSubscribers
           .filter(sub => sub.after)
-          .forEach(sub => sub.after(action, this.state, /*isError:*/false, res))
+          .forEach(sub => sub.after(action, this.state, /* isError: */false, res))
       } catch (e) {
         if (process.env.NODE_ENV !== 'production') {
           console.warn(`[vuex] error in after action subscribers: `)
@@ -157,19 +157,19 @@ export class Store {
       }
       return res
     })
-    .catch(errorResult => {
-      try {
-        this._actionSubscribers
-          .filter(sub => sub.after)
-          .forEach(sub => sub.after(action, this.state, /*isError:*/true, errorResult))
-      } catch (e) {
-        if (process.env.NODE_ENV !== 'production') {
-          console.warn(`[vuex] error in after action subscribers: `)
-          console.error(e)
+      .catch(errorResult => {
+        try {
+          this._actionSubscribers
+            .filter(sub => sub.after)
+            .forEach(sub => sub.after(action, this.state, /* isError: */true, errorResult))
+        } catch (e) {
+          if (process.env.NODE_ENV !== 'production') {
+            console.warn(`[vuex] error in after action subscribers: `)
+            console.error(e)
+          }
         }
-      }
-      throw errorResult
-    })
+        throw errorResult
+      })
   }
 
   subscribe (fn) {

--- a/test/unit/modules.spec.js
+++ b/test/unit/modules.spec.js
@@ -669,12 +669,12 @@ describe('Modules', () => {
       )
     })
 
-    it('action before/after subscribers', (done) => {
+    it('action before/after subscribers with resolve()', (done) => {
       const beforeSpy = jasmine.createSpy()
       const afterSpy = jasmine.createSpy()
       const store = new Vuex.Store({
         actions: {
-          [TEST]: () => Promise.resolve()
+          [TEST]: () => Promise.resolve('resolve')
         },
         plugins: [
           store => {
@@ -694,7 +694,43 @@ describe('Modules', () => {
       Vue.nextTick(() => {
         expect(afterSpy).toHaveBeenCalledWith(
           { type: TEST, payload: 2 },
-          store.state
+          store.state,
+          false,
+          'resolve'
+        )
+        done()
+      })
+    })
+  })
+
+    it('action before/after subscribers with reject()', (done) => {
+      const beforeSpy = jasmine.createSpy()
+      const afterSpy = jasmine.createSpy()
+      const store = new Vuex.Store({
+        actions: {
+          [TEST]: () => Promise.reject('reject')
+        },
+        plugins: [
+          store => {
+            store.subscribeAction({
+              before: beforeSpy,
+              after: afterSpy
+            })
+          }
+        ]
+      })
+      store.dispatch(TEST, 2)
+      expect(beforeSpy).toHaveBeenCalledWith(
+        { type: TEST, payload: 2 },
+        store.state
+      )
+      expect(afterSpy).not.toHaveBeenCalled()
+      Vue.nextTick(() => {
+        expect(afterSpy).toHaveBeenCalledWith(
+          { type: TEST, payload: 2 },
+          store.state,
+          false,
+          'reject'
         )
         done()
       })


### PR DESCRIPTION
That cause might be a promise.rejection or js error.

This way the action subscribers of the 'after' would not miss the end of the action,
as they would receive the existing 'action' and 'state' parameters, and the additional 'isSuccess' and 'errorResult' values. 
This applies for the then-side of the promise too, but there they would receive the result.

The true/false value might be useful for after action handlers, but the result might be too tempting to be used for modification for example, might be that too much info is handled out in this way. The same goes for the success-side of the after subscribers too.

While reviewing mind that: I cannot access github directly (firewalls), so this was a manual insertion of the locally working code. Typos might came along! (: In case there is a problem, tell me and I fix that, or say a thank you for your fix (: