### PR TITLE
#1591 refactor: do not mutate mutation payload in the todo app example

### DIFF
--- a/examples/todomvc/store/mutations.js
+++ b/examples/todomvc/store/mutations.js
@@ -15,7 +15,6 @@ export const mutations = {
   },
 
   editTodo (state, { todo, text = todo.text, done = todo.done }) {
-    todo.text = text
-    todo.done = done
+    state.todos.splice(state.todos.indexOf(todo), 1, { ...todo, text, done })
   }
 }

--- a/examples/todomvc/store/mutations.js
+++ b/examples/todomvc/store/mutations.js
@@ -15,6 +15,12 @@ export const mutations = {
   },
 
   editTodo (state, { todo, text = todo.text, done = todo.done }) {
-    state.todos.splice(state.todos.indexOf(todo), 1, { ...todo, text, done })
+    const index = state.todos.indexOf(todo)
+
+    state.todos.splice(index, 1, {
+      ...todo,
+      text,
+      done
+    })
   }
 }


### PR DESCRIPTION
Issue #1591

This PR refactors the mutation logic in todo example to not mutate mutation payload directly in the simplest form.

It's still using the reference to todo (at `indexOf`) but I think it's more clearer than before that Vuex recommends to not mutate payload directly.