### PR TITLE
fix(#1571): remove undefined payload from dispatch

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -384,7 +384,7 @@ function makeLocalContext (store, namespace, path) {
         }
       }
 
-      return store.dispatch(type, payload)
+      return payload ? store.dispatch(type, payload) : store.dispatch(type)
     },
 
     commit: noNamespace ? store.commit : (_type, _payload, _options) => {

--- a/test/unit/store.spec.js
+++ b/test/unit/store.spec.js
@@ -77,6 +77,30 @@ describe('Store', () => {
     expect(store.state.a).toBe(3)
   })
 
+  it('dispatching actions without a payload', () => {
+    const store = new Vuex.Store({
+      state: {
+        a: false
+      },
+      mutations: {
+        [TEST] (state) {
+          state.a = true
+        }
+      },
+      actions: {
+        [TEST] ({ commit }) {
+          expect(arguments.length).toBe(1)
+          commit(TEST)
+        },
+        action ({ dispatch }) {
+          dispatch(TEST)
+        }
+      }
+    })
+    store.dispatch('action')
+    expect(store.state.a).toBe(true)
+  })
+
   it('dispatching with object style', () => {
     const store = new Vuex.Store({
       state: {


### PR DESCRIPTION
Fix for #1571

Removes unused payloads from the dispatch calls.

- Original PR at https://github.com/vuejs/vuex/pull/1573.
- Solution was proposed at https://github.com/vuejs/vuex/issues/1571#issuecomment-505838341