### PR TITLE
refactor: remove extra loops in dispatch()

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -136,8 +136,7 @@ export class Store {
     try {
       this._actionSubscribers
         .slice() // shallow copy to prevent iterator invalidation if subscriber synchronously calls unsubscribe
-        .filter(sub => sub.before)
-        .forEach(sub => sub.before(action, this.state))
+        .forEach(sub => { if (sub.before) sub.before(action, this.state) })
     } catch (e) {
       if (process.env.NODE_ENV !== 'production') {
         console.warn(`[vuex] error in before action subscribers: `)
@@ -152,8 +151,7 @@ export class Store {
     return result.then(res => {
       try {
         this._actionSubscribers
-          .filter(sub => sub.after)
-          .forEach(sub => sub.after(action, this.state))
+          .forEach(sub => { if (sub.after) sub.after(action, this.state) })
       } catch (e) {
         if (process.env.NODE_ENV !== 'production') {
           console.warn(`[vuex] error in after action subscribers: `)


### PR DESCRIPTION
This commit replaces two chained `filter()`-`forEach()` sequences in `dispatch()` with single `forEach()`s.