### PR TITLE
docs: make obvious where to import store from

### DIFF
--- a/docs/guide/modules.md
+++ b/docs/guide/modules.md
@@ -280,7 +280,9 @@ export function createPlugin (options = {}) {
 You can register a module **after** the store has been created with the `store.registerModule` method:
 
 ``` js
-import { store } from 'vuex'
+import Vuex from 'vuex'
+
+const store = new Vuex.Store({ /* options */ })
 
 // register a module `myModule`
 store.registerModule('myModule', {

--- a/docs/guide/modules.md
+++ b/docs/guide/modules.md
@@ -280,6 +280,8 @@ export function createPlugin (options = {}) {
 You can register a module **after** the store has been created with the `store.registerModule` method:
 
 ``` js
+import { store } from 'vuex'
+
 // register a module `myModule`
 store.registerModule('myModule', {
   // ...


### PR DESCRIPTION
As we browse through the modules page, it is unclear where the `store` is imported from.

Since it is a one liner, I thought it would clarify to have the import explicitly here.

Tell me what you think.