### PR TITLE
build: add vue as a peer dependency (#1681)

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,9 @@
     "url": "https://github.com/vuejs/vuex/issues"
   },
   "homepage": "https://github.com/vuejs/vuex#readme",
+  "peerDependencies": {
+    "vue": "^2.0.0"
+  },
   "devDependencies": {
     "babel-core": "^6.22.1",
     "babel-loader": "^7.1.2",


### PR DESCRIPTION
Issue: #1681 

This PR adds Vue as a peer dependency. It should help using Vuex with Yarn 2 too.