### PR TITLE
Throw an error when an unknown mutation is requested

### DIFF
--- a/dist/vuex.common.js
+++ b/dist/vuex.common.js
@@ -385,7 +385,7 @@ Store.prototype.commit = function commit (_type, _payload, _options) {
   var entry = this._mutations[type];
   if (!entry) {
     if (process.env.NODE_ENV !== 'production') {
-      console.error(("[vuex] unknown mutation type: " + type));
+      throw new Error(("[vuex] unknown mutation type: " + type))
     }
     return
   }

--- a/src/store.js
+++ b/src/store.js
@@ -92,7 +92,7 @@ export class Store {
     const entry = this._mutations[type]
     if (!entry) {
       if (process.env.NODE_ENV !== 'production') {
-        console.error(`[vuex] unknown mutation type: ${type}`)
+        throw new Error(`[vuex] unknown mutation type: ${type}`)
       }
       return
     }

--- a/test/unit/hot-reload.spec.js
+++ b/test/unit/hot-reload.spec.js
@@ -357,7 +357,7 @@ describe('Hot Reload', () => {
     expect(actionSpy.calls.count()).toBe(2)
 
     // should not be called
-    store.commit('a/foo')
+    expect(function () { store.commit('a/foo') }).toThrow()
     expect(mutationSpy.calls.count()).toBe(1)
 
     // should be called


### PR DESCRIPTION
I noticed when I was running my unit tests that I got a number of `[vuex] unknown mutation type` errors in the log, but without any tests actually failing.  This was due to my having (deliberately) removed a store which provided those mutations.  This also removed those tests which were explicitly exercising that mutation, so there were no longer any tests which actually checked that the mutation worked.  So, that all checks out.

However...  there still were all the the places which were calling the now unknown mutation without triggering any errors of their own in _their_ tests.  This pull request changes the reaction to not finding a mutation to thow an error instead of swallowing the problem.  This will (correctly, to my mind) cause upstream code which erroneously commits a non-existant mutation to fail.