### PR TITLE
docs: add docs and typings for the new `hasModule` method

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -238,6 +238,14 @@ const store = new Vuex.Store({ ...options })
 
   Unregister a dynamic module. [Details](../guide/modules.md#dynamic-module-registration)
 
+### hasModule
+
+- `hasModule(path: string | Array<string>)`
+
+  Check if the module with the given name is already registered. [Details](../guide/modules.md#dynamic-module-registration)
+
+  > New in 3.2.0
+
 ### hotUpdate
 
 -  `hotUpdate(newOptions: Object)`

--- a/docs/guide/modules.md
+++ b/docs/guide/modules.md
@@ -301,6 +301,8 @@ Dynamic module registration makes it possible for other Vue plugins to also leve
 
 You can also remove a dynamically registered module with `store.unregisterModule(moduleName)`. Note you cannot remove static modules (declared at store creation) with this method.
 
+Note that you may check if the module is already registered to the store or not via `store.hasModule(moduleName)` method.
+
 #### Preserving state
 
 It may be likely that you want to preserve the previous state when registering a new module, such as preserving state from a Server Side Rendered app. You can achieve this with `preserveState` option: `store.registerModule('a', module, { preserveState: true })`

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -28,6 +28,9 @@ export declare class Store<S> {
   unregisterModule(path: string): void;
   unregisterModule(path: string[]): void;
 
+  hasModule(path: string): boolean;
+  hasModule(path: string[]): boolean;
+
   hotUpdate(options: {
     actions?: ActionTree<S, S>;
     mutations?: MutationTree<S>;

--- a/types/test/index.ts
+++ b/types/test/index.ts
@@ -292,6 +292,8 @@ namespace RegisterModule {
     state: { value: 1 }
   });
 
+  store.hasModule('a')
+
   store.registerModule(["a", "b"], {
     state: { value: 2 }
   });
@@ -299,6 +301,8 @@ namespace RegisterModule {
   store.registerModule(["a", "b"], {
     state: { value: 2 }
   }, { preserveState: true });
+
+  store.hasModule(['a', 'b'])
 
   store.unregisterModule(["a", "b"]);
   store.unregisterModule("a");


### PR DESCRIPTION
This PR adds docs and typing for the new `hasModule` API which was added at #834.