### PR TITLE
refactor: Register nested modules through more uniform naming 

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -187,7 +187,7 @@ export class Store {
   }
 
   registerModule (path, rawModule, options = {}) {
-    if (typeof path === 'string') path = [path]
+    if (typeof path === 'string') path = path.split('/').filter(Boolean)
 
     if (process.env.NODE_ENV !== 'production') {
       assert(Array.isArray(path), `module path must be a string or an Array.`)
@@ -201,7 +201,7 @@ export class Store {
   }
 
   unregisterModule (path) {
-    if (typeof path === 'string') path = [path]
+    if (typeof path === 'string') path = path.split('/').filter(Boolean)
 
     if (process.env.NODE_ENV !== 'production') {
       assert(Array.isArray(path), `module path must be a string or an Array.`)
@@ -216,7 +216,7 @@ export class Store {
   }
 
   hasModule (path) {
-    if (typeof path === 'string') path = [path]
+    if (typeof path === 'string') path = path.split('/').filter(Boolean)
 
     if (process.env.NODE_ENV !== 'production') {
       assert(Array.isArray(path), `module path must be a string or an Array.`)


### PR DESCRIPTION
Usually people prefer to register nested modules `nested / myModule`  by passing in ` nested / myModule` instead of `['nested', 'myModule']`, which is more unified with the namespace.In addition,this modification will consider a single empty string path to be the root module.