### PR TITLE
types: add subscribe options type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -18,8 +18,8 @@ export declare class Store<S> {
   dispatch: Dispatch;
   commit: Commit;
 
-  subscribe<P extends MutationPayload>(fn: (mutation: P, state: S) => any): () => void;
-  subscribeAction<P extends ActionPayload>(fn: SubscribeActionOptions<P, S>): () => void;
+  subscribe<P extends MutationPayload>(fn: (mutation: P, state: S) => any, options?: SubscribeOptions): () => void;
+  subscribeAction<P extends ActionPayload>(fn: SubscribeActionOptions<P, S>, options?: SubscribeOptions): () => void;
   watch<T>(getter: (state: S, getters: any) => T, cb: (value: T, oldValue: T) => void, options?: WatchOptions): () => void;
 
   registerModule<T>(path: string, module: Module<T, S>, options?: ModuleOptions): void;
@@ -70,6 +70,10 @@ export interface MutationPayload extends Payload {
 
 export interface ActionPayload extends Payload {
   payload: any;
+}
+
+export interface SubscribeOptions {
+  prepend?: boolean
 }
 
 export type ActionSubscriber<P, S> = (action: P, state: S) => any;

--- a/types/test/index.ts
+++ b/types/test/index.ts
@@ -39,6 +39,8 @@ namespace StoreInstance {
     state.value;
   });
 
+  store.subscribe(() => {}, { prepend: true });
+
   store.subscribeAction((action, state) => {
     action.type;
     action.payload;
@@ -73,6 +75,8 @@ namespace StoreInstance {
       state.value;
     }
   });
+
+  store.subscribeAction({}, { prepend: true });
 
   store.replaceState({ value: 10 });
 }


### PR DESCRIPTION
This PR adds missing types for subscribe `prepend` option merged via #1358.