### PR TITLE
docs(ja): translate new options for the `subscribe` methods and logger plugin

### DIFF
--- a/docs/ja/api/README.md
+++ b/docs/ja/api/README.md
@@ -175,7 +175,7 @@ const store = new Vuex.Store({ ...options })
 
 ### subscribe
 
-- `subscribe(handler: Function): Function`
+- `subscribe(handler: Function, options?: Object): Function`
 
   ストアへのミューテーションを購読します。`handler` は、全てのミューテーションの後に呼ばれ、引数として、ミューテーション ディスクリプタとミューテーション後の状態を受け取ります。
 
@@ -186,13 +186,19 @@ const store = new Vuex.Store({ ...options })
   })
   ```
 
+  デフォルトでは、新しい `handler` はチェーンの最後に登録されます。つまり、先に追加された他の `hanlder` が呼び出された後に実行されます。`prepend: true` を `options` に設定することで、`handler` をチェーンの最初に登録することができます。
+
+  ``` js
+  store.subscribe(handler, { prepend: true })
+  ```
+
   購読を停止するには、返された unsubscribe 関数呼び出します。
 
   プラグインの中でもっともよく利用されます。[詳細](../guide/plugins.md)
 
 ### subscribeAction
 
-- `subscribeAction(handler: Function)`
+- `subscribeAction(handler: Function, options?: Object): Function`
 
   > 2.5.0 で新規追加
 
@@ -203,6 +209,12 @@ const store = new Vuex.Store({ ...options })
     console.log(action.type)
     console.log(action.payload)
   })
+  ```
+
+  デフォルトでは、新しい `handler` はチェーンの最後に登録されます。つまり、先に追加された他の `hanlder` が呼び出された後に実行されます。`prepend: true` を `options` に設定することで、`handler` をチェーンの最初に登録することができます。
+
+  ``` js
+  store.subscribeAction(handler, { prepend: true })
   ```
 
 　購読を停止するには、返された購読解除関数を呼びます。

--- a/docs/ja/guide/plugins.md
+++ b/docs/ja/guide/plugins.md
@@ -109,16 +109,27 @@ const logger = createLogger({
     // `mutation` は `{ type, payload }` です
     return mutation.type !== "aBlacklistedMutation"
   },
+  actionFilter (action, state) {
+    // `filter` と同等ですが、アクション用です
+    // `action` は `{ type, payloed }` です
+    return action.type !== "aBlacklistedAction"
+  },
   transformer (state) {
     // ロギングの前に、状態を変換します
     // 例えば、特定のサブツリーのみを返します
     return state.subTree
+  },
+  actionTransformer (action) {
+    // `mutationTransformer` と同等ですが、アクション用です
+    return action.type
   },
   mutationTransformer (mutation) {
     // ミューテーションは、`{ type, payload }` の形式でログ出力されます
     // 任意の方法でそれをフォーマットできます
     return mutation.type
   },
+  logActions: true, // アクションログを出力します。
+  logMutations: true, // ミューテーションログを出力します。
   logger: console, // `console` API の実装, デフォルトは `console`
 })
 ```


### PR DESCRIPTION
This PR adds the Japanese translation for the new options added to `subscribe` methods and logger plugin.