### PR TITLE
fix: import requirements for  `this.$store` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ Place the following code in your project to allow `this.$store` to be typed corr
 ```ts
 // vuex-shim.d.ts
 
+import { Store } from "vuex";
+import { ComponentCustomProperties } from "vue";
+
 declare module "@vue/runtime-core" {
   // Declare your own store states.
   interface State {


### PR DESCRIPTION
To work global typings for `this.$store` need to import `Store` and `ComponentCustomProperties`