### PR TITLE
types: add `useStore` function (#1736)

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -43,6 +43,8 @@ export declare class Store<S> {
 
 export function createStore<S>(options: StoreOptions<S>): Store<S>;
 
+export function useStore<S = any>(): Store<S>;
+
 export interface Dispatch {
   (type: string, payload?: any, options?: DispatchOptions): Promise<any>;
   <P extends Payload>(payloadWithType: P, options?: DispatchOptions): Promise<any>;

--- a/types/test/index.ts
+++ b/types/test/index.ts
@@ -78,6 +78,18 @@ namespace StoreInstance {
   store.replaceState({ value: 10 });
 }
 
+namespace UseStoreFunction {
+  interface State {
+    a: string
+  }
+
+  const storeWithState = Vuex.useStore<State>()
+  storeWithState.state.a
+
+  const storeAsAny = Vuex.useStore()
+  storeAsAny.state.a
+}
+
 namespace RootModule {
   const store = new Vuex.Store({
     state: {


### PR DESCRIPTION
fix #1736

This PR adds missing `useStore` function typings. Users may provide `State` as a generics, or use without it to get `Store<any>` type.