### PR TITLE
docs: add Dynamic module hot reloading example

### DIFF
--- a/docs/guide/hot-reload.md
+++ b/docs/guide/hot-reload.md
@@ -49,12 +49,12 @@ If you use modules exclusively, you can use `require.context` to load and hot re
 
 ```js
 // store.js
-import Vue from 'vue';
-import Vuex from 'vuex';
+import Vue from 'vue'
+import Vuex from 'vuex'
 
 // Load all modules.
 function loadModules() {
-  const context = require.context("./modules", false, /([a-z_]+)\.js$/i);
+  const context = require.context("./modules", false, /([a-z_]+)\.js$/i)
 
   const modules = context
     .keys()
@@ -65,29 +65,27 @@ function loadModules() {
         [name]: context(key).default,
       }),
       {}
-    );
+    )
 
-  return { context, modules };
+  return { context, modules }
 }
 
-const { context, modules } = loadModules();
+const { context, modules } = loadModules()
 
-Vue.use(Vuex);
+Vue.use(Vuex)
 
 const store = new Vuex.Store({
   modules
-});
-
-export default store;
+})
 
 if (module.hot) {
   // Hot reload whenever any module changes.
   module.hot.accept(context.id, () => {
-    const { modules } = loadModules();
+    const { modules } = loadModules()
 
     store.hotUpdate({
       modules,
-    });
-  });
+    })
+  })
 }
 ```

--- a/docs/guide/hot-reload.md
+++ b/docs/guide/hot-reload.md
@@ -4,8 +4,6 @@ Vuex supports hot-reloading mutations, modules, actions and getters during devel
 
 For mutations and modules, you need to use the `store.hotUpdate()` API method:
 
-## Example
-
 ``` js
 // store.js
 import Vue from 'vue'

--- a/docs/guide/hot-reload.md
+++ b/docs/guide/hot-reload.md
@@ -62,7 +62,7 @@ function loadModules() {
     .reduce(
       (modules, { key, name }) => ({
         ...modules,
-        [name]: context(key).default,
+        [name]: context(key).default
       }),
       {}
     )
@@ -84,7 +84,7 @@ if (module.hot) {
     const { modules } = loadModules()
 
     store.hotUpdate({
-      modules,
+      modules
     })
   })
 }

--- a/docs/guide/hot-reload.md
+++ b/docs/guide/hot-reload.md
@@ -4,6 +4,8 @@ Vuex supports hot-reloading mutations, modules, actions and getters during devel
 
 For mutations and modules, you need to use the `store.hotUpdate()` API method:
 
+## Example
+
 ``` js
 // store.js
 import Vue from 'vue'
@@ -42,3 +44,52 @@ if (module.hot) {
 ```
 
 Checkout the [counter-hot example](https://github.com/vuejs/vuex/tree/dev/examples/counter-hot) to play with hot-reload.
+
+## Dynamic module hot reloading
+
+If you use modules exclusively, you can use `require.context` to load and hot reload all modules dynamically.
+
+```js
+// store.js
+import Vue from 'vue';
+import Vuex from 'vuex';
+
+// Load all modules.
+function loadModules() {
+  const context = require.context("./modules", false, /([a-z_]+)\.js$/i);
+
+  const modules = context
+    .keys()
+    .map((key) => ({ key, name: key.match(/([a-z_]+)\.js$/i)[1] }))
+    .reduce(
+      (modules, { key, name }) => ({
+        ...modules,
+        [name]: context(key).default,
+      }),
+      {}
+    );
+
+  return { context, modules };
+}
+
+const { context, modules } = loadModules();
+
+Vue.use(Vuex);
+
+const store = new Vuex.Store({
+  modules
+});
+
+export default store;
+
+if (module.hot) {
+  // Hot reload whenever any module changes.
+  module.hot.accept(context.id, () => {
+    const { modules } = loadModules();
+
+    store.hotUpdate({
+      modules,
+    });
+  });
+}
+```


### PR DESCRIPTION
I have looked for a way to load and hot reload Vuex modules systematically, rather than specifying them explictly.

Adapted from: https://github.com/kazupon/vue-i18n/pull/865