### PR TITLE
docs: add docs for the new `error` option for `subscribeAction` method

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -233,7 +233,20 @@ const store = new Vuex.Store({ ...options })
   })
   ```
 
-  Most commonly used in plugins. [Details](../guide/plugins.md)
+  > New in 3.4.0
+
+  Since 3.4.0, `subscribeAction` can also specify the `error` option to catch the error thrown during the action dispatch. The `error` option will take an additional `error` object as the 3rd argument.
+
+  ``` js
+  store.subscribeAction({
+    after: (action, state, error) => {
+      console.log(`error action ${action.type}`)
+      console.error(error)
+    }
+  })
+  ```
+
+  The `subscribeAction` method is most commonly used in plugins. [Details](../guide/plugins.md)
 
 ### registerModule
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -235,11 +235,11 @@ const store = new Vuex.Store({ ...options })
 
   > New in 3.4.0
 
-  Since 3.4.0, `subscribeAction` can also specify the `error` option to catch the error thrown during the action dispatch. The `error` option will take an additional `error` object as the 3rd argument.
+  Since 3.4.0, `subscribeAction` can also specify an `error` handler to catch an error thrown when an action is dispatched. The function will receive an `error` object as the third argument.
 
   ``` js
   store.subscribeAction({
-    after: (action, state, error) => {
+    error: (action, state, error) => {
       console.log(`error action ${action.type}`)
       console.error(error)
     }


### PR DESCRIPTION
Add API docs for the new `error` option added to the `subscribeAction` method via #1740.