### PR TITLE
refactor: remove node env flag

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -9,11 +9,9 @@ module.exports = {
   },
   testMatch: ['<rootDir>/test/unit/**/*.spec.js'],
   testPathIgnorePatterns: ['/node_modules/'],
-  setupFilesAfterEnv: [
-    './test/setup.js'
-  ],
-  "transform": {
-    "^.+\\.js$": "<rootDir>/node_modules/babel-jest"
+  setupFilesAfterEnv: ['./test/setup.js'],
+  transform: {
+    '^.+\\.js$': '<rootDir>/node_modules/babel-jest'
   },
   coverageDirectory: 'coverage',
   coverageReporters: ['json', 'lcov', 'text-summary', 'clover'],

--- a/src/store.js
+++ b/src/store.js
@@ -10,7 +10,7 @@ export function createStore (options) {
 
 export class Store {
   constructor (options = {}) {
-    if (process.env.NODE_ENV !== 'production') {
+    if (__DEV__) {
       assert(typeof Promise !== 'undefined', `vuex requires a Promise polyfill in this browser.`)
       assert(this instanceof Store, `store must be called with the new operator.`)
     }


### PR DESCRIPTION
Replaces the orphaned `process.env.NODE_ENV` with the new global `__DEV__`.
