### PR TITLE
docs: Fix missing information in the guide.

### DIFF
--- a/docs/zh/guide/README.md
+++ b/docs/zh/guide/README.md
@@ -20,6 +20,8 @@
 import Vue from 'vue'
 import Vuex from 'vuex'
 
+Vue.use(Vuex);
+
 const store = new Vuex.Store({
   state: {
     count: 0


### PR DESCRIPTION
Missing `Vue.use(Vuex);`.