### PR TITLE
Fix: Document return value when item was not found

### DIFF
--- a/test/unit/util.spec.js
+++ b/test/unit/util.spec.js
@@ -1,9 +1,14 @@
 import { find, deepCopy, forEachValue, isObject, isPromise, assert } from '@/util'
 
 describe('util', () => {
-  it('find', () => {
+  it('find: returns item when it was found', () => {
     const list = [33, 22, 112, 222, 43]
     expect(find(list, function (a) { return a % 2 === 0 })).toEqual(22)
+  })
+
+  it('find: returns undefined when item was not found', () => {
+    const list = [1, 2, 3]
+    expect(find(list, function (a) { return a === 9000 })).toEqual(undefined)
   })
 
   it('deepCopy: normal structure', () => {


### PR DESCRIPTION
This PR

* [x] documents the return value of `find` when an item was not found

💁‍♂️ I'm new to `vuejs` and `vuex`, so I'm not sure if this makes sense - but I could not find any documentation on what would be returned when an item is not found. What do you think?