### PR TITLE
feat: include logger plugin to the core export

### DIFF
--- a/src/index.cjs.js
+++ b/src/index.cjs.js
@@ -1,5 +1,6 @@
 import { Store, install } from './store'
 import { mapState, mapMutations, mapGetters, mapActions, createNamespacedHelpers } from './helpers'
+import createLogger from './plugins/logger'
 
 export default {
   Store,
@@ -9,5 +10,6 @@ export default {
   mapMutations,
   mapGetters,
   mapActions,
-  createNamespacedHelpers
+  createNamespacedHelpers,
+  createLogger
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import { Store, install } from './store'
 import { mapState, mapMutations, mapGetters, mapActions, createNamespacedHelpers } from './helpers'
+import createLogger from './plugins/logger'
 
 export default {
   Store,
@@ -9,7 +10,8 @@ export default {
   mapMutations,
   mapGetters,
   mapActions,
-  createNamespacedHelpers
+  createNamespacedHelpers,
+  createLogger
 }
 
 export {
@@ -19,5 +21,6 @@ export {
   mapMutations,
   mapGetters,
   mapActions,
-  createNamespacedHelpers
+  createNamespacedHelpers,
+  createLogger
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,8 +4,10 @@ import _Vue, { WatchOptions } from "vue";
 import "./vue";
 
 import { mapState, mapMutations, mapGetters, mapActions, createNamespacedHelpers } from "./helpers";
+import createLogger from "./logger";
 
 export * from "./helpers";
+export * from "./logger";
 
 export declare class Store<S> {
   constructor(options: StoreOptions<S>);
@@ -147,6 +149,8 @@ export interface ModuleTree<R> {
   [key: string]: Module<any, R>;
 }
 
+export { createLogger }
+
 declare const _default: {
   Store: typeof Store;
   install: typeof install;
@@ -155,5 +159,6 @@ declare const _default: {
   mapGetters: typeof mapGetters,
   mapActions: typeof mapActions,
   createNamespacedHelpers: typeof createNamespacedHelpers,
+  createLogger: typeof createLogger
 };
 export default _default;

--- a/types/logger.d.ts
+++ b/types/logger.d.ts
@@ -1,0 +1,14 @@
+import { Payload, Plugin } from "./index";
+
+export interface LoggerOption<S> {
+  collapsed?: boolean;
+  filter?: <P extends Payload>(mutation: P, stateBefore: S, stateAfter: S) => boolean;
+  transformer?: (state: S) => any;
+  mutationTransformer?: <P extends Payload>(mutation: P) => any;
+  actionFilter?: <P extends Payload>(action: P, state: S) => boolean;
+  actionTransformer?: <P extends Payload>(action: P) => any;
+  logMutations?: boolean;
+  logActions?: boolean;
+}
+
+export default function createLogger<S>(option?: LoggerOption<S>): Plugin<S>;

--- a/types/test/index.ts
+++ b/types/test/index.ts
@@ -1,6 +1,5 @@
 import Vue from "vue";
 import * as Vuex from "../index";
-import createLogger from "../../dist/logger";
 
 Vue.use(Vuex);
 
@@ -438,7 +437,7 @@ namespace Plugins {
     });
   }
 
-  const logger = createLogger<{ value: number }>({
+  const logger = Vuex.createLogger<{ value: number }>({
     collapsed: true,
     transformer: state => state.value,
     mutationTransformer: (mutation: { type: string }) => mutation.type


### PR DESCRIPTION
This PR add `logger` plugin to the core export to be able to support ESM build for the `logger` plugin. Issue was mentioned at https://github.com/vitejs/vite/issues/334.

This is for Vuex 3, so I'm keeping the individual bundle as is to avoid braking change. For Vuex 4, I'm planning to remove the logger bundle entirely.

Planning to follow up the PR with documentation update as well for the next release.