### PR TITLE
fix: warn when unregistering non existing module

### DIFF
--- a/src/module/module-collection.js
+++ b/src/module/module-collection.js
@@ -49,8 +49,9 @@ export default class ModuleCollection {
   unregister (path) {
     const parent = this.get(path.slice(0, -1))
     const key = path[path.length - 1]
+    const child = parent.getChild(key)
 
-    if (!parent.getChild(key)) {
+    if (!child) {
       if (__DEV__) {
         console.warn(
           `[vuex] trying to unregister module '${key}', which is ` +
@@ -60,7 +61,7 @@ export default class ModuleCollection {
       return
     }
 
-    if (!parent.getChild(key).runtime) {
+    if (!child.runtime) {
       return
     }
 

--- a/src/module/module-collection.js
+++ b/src/module/module-collection.js
@@ -49,7 +49,20 @@ export default class ModuleCollection {
   unregister (path) {
     const parent = this.get(path.slice(0, -1))
     const key = path[path.length - 1]
-    if (!parent.getChild(key).runtime) return
+
+    if (!parent.getChild(key)) {
+      if (__DEV__) {
+        console.warn(
+          `[vuex] trying to unregister module '${key}', which is ` +
+          `not registered`
+        )
+      }
+      return
+    }
+
+    if (!parent.getChild(key).runtime) {
+      return
+    }
 
     parent.removeChild(key)
   }

--- a/test/unit/module/module-collection.spec.js
+++ b/test/unit/module/module-collection.spec.js
@@ -92,4 +92,12 @@ describe('ModuleCollection', () => {
     collection.unregister(['a'])
     expect(collection.get(['a']).state.value).toBe(true)
   })
+
+  it('warns when unregistering non existing module', () => {
+    const spy = jest.spyOn(console, 'warn').mockImplementation()
+
+    const collection = new ModuleCollection({})
+    collection.unregister(['a'])
+    expect(spy).toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
close #1426

This PR adds warning when removing non existing module. Currently, it fails due to `runtime` not exist in `undefined` error. It's follow up PR for #1426.

It will only warn in development mode, so it will not introduce any braking changes.