### PR TITLE
Support modules and state functions in Store typings

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -15,17 +15,17 @@ export declare class Store<S, T extends ModuleTree<S> = {}> {
   readonly state: State<S, T>;
   readonly getters: any;
 
-  replaceState(state: S): void;
+  replaceState(state: State<S, T>): void;
 
   dispatch: Dispatch;
   commit: Commit;
 
-  subscribe<P extends MutationPayload>(fn: (mutation: P, state: S) => any, options?: SubscribeOptions): () => void;
-  subscribeAction<P extends ActionPayload>(fn: SubscribeActionOptions<P, S>, options?: SubscribeOptions): () => void;
-  watch<T>(getter: (state: S, getters: any) => T, cb: (value: T, oldValue: T) => void, options?: WatchOptions): () => void;
+  subscribe<P extends MutationPayload>(fn: (mutation: P, state: State<S, T>) => any, options?: SubscribeOptions): () => void;
+  subscribeAction<P extends ActionPayload>(fn: SubscribeActionOptions<P, State<S, T>>, options?: SubscribeOptions): () => void;
+  watch<U>(getter: (state: State<S, T>, getters: any) => U, cb: (value: U, oldValue: U) => void, options?: WatchOptions): () => void;
 
-  registerModule<T>(path: string, module: Module<T, S>, options?: ModuleOptions): void;
-  registerModule<T>(path: string[], module: Module<T, S>, options?: ModuleOptions): void;
+  registerModule<U>(path: string, module: Module<U, State<S, T>>, options?: ModuleOptions): void;
+  registerModule<U>(path: string[], module: Module<U, State<S, T>>, options?: ModuleOptions): void;
 
   unregisterModule(path: string): void;
   unregisterModule(path: string[]): void;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -107,7 +107,7 @@ export interface StoreOptions<S, T extends ModuleTree<S> = ModuleTree<S>> {
   getters?: GetterTree<S, S>;
   actions?: ActionTree<S, S>;
   mutations?: MutationTree<S>;
-  modules?: T;
+  modules?: T & ModuleTree<S>;
   plugins?: Plugin<S>[];
   strict?: boolean;
   devtools?: boolean;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -9,10 +9,10 @@ import createLogger from "./logger";
 export * from "./helpers";
 export * from "./logger";
 
-export declare class Store<S> {
-  constructor(options: StoreOptions<S>);
+export declare class Store<S, T extends ModuleTree<S> = {}> {
+  constructor(options: StoreOptions<S, T>);
 
-  readonly state: S;
+  readonly state: State<S, T>;
   readonly getters: any;
 
   replaceState(state: S): void;
@@ -42,6 +42,10 @@ export declare class Store<S> {
 }
 
 export declare function install(Vue: typeof _Vue): void;
+
+export type State<S, T extends ModuleTree<S>> = (S extends () => any ? ReturnType<S> : S) & {
+  [P in keyof T]: State<T[P]['state'], T[P] extends { modules: object } ? T[P]['modules'] : {}>
+}
 
 export interface Dispatch {
   (type: string, payload?: any, options?: DispatchOptions): Promise<any>;
@@ -98,12 +102,12 @@ export interface CommitOptions {
   root?: boolean;
 }
 
-export interface StoreOptions<S> {
+export interface StoreOptions<S, T extends ModuleTree<S> = ModuleTree<S>> {
   state?: S | (() => S);
   getters?: GetterTree<S, S>;
   actions?: ActionTree<S, S>;
   mutations?: MutationTree<S>;
-  modules?: ModuleTree<S>;
+  modules?: T;
   plugins?: Plugin<S>[];
   strict?: boolean;
   devtools?: boolean;

--- a/types/test/index.ts
+++ b/types/test/index.ts
@@ -136,6 +136,192 @@ namespace StoreInstance {
   store.replaceState({ value: 10 });
 }
 
+namespace StoreInstanceWithModules {
+  const store = new Vuex.Store({
+    state: {
+      value: 0
+    },
+    modules: {
+      a: {
+        state: { value: 1 },
+        modules: {
+          b: {
+            state: { value: 2 }
+          }
+        }
+      },
+      c: {
+        state: { value: 1 },
+      }
+    }
+  });
+
+  store.state.value;
+  store.state.a.value;
+  store.state.a.b.value;
+  store.state.c.value;
+  store.getters.foo;
+
+  store.watch(state => state.value + state.a.b.value + state.c.value, value => {
+    value = value + 1;
+  }, {
+    immediate: true,
+    deep: true
+  });
+
+  store.subscribe((mutation, state) => {
+    mutation.type;
+    mutation.payload;
+    state.value;
+    state.a.value;
+    state.a.b.value;
+    state.c.value;
+  });
+
+  store.subscribeAction((action, state) => {
+    action.type;
+    action.payload;
+    state.value;
+    state.a.value;
+    state.a.b.value;
+    state.c.value;
+  });
+
+  store.subscribeAction({
+    before(action, state) {
+      action.type;
+      action.payload;
+      state.value;
+      state.a.value;
+      state.a.b.value;
+      state.c.value;
+    }
+  });
+
+  store.subscribeAction({
+    before(action, state) {
+      action.type;
+      action.payload;
+      state.value;
+      state.a.value;
+      state.a.b.value;
+      state.c.value;
+    },
+    after(action, state) {
+      action.type;
+      action.payload;
+      state.value;
+      state.a.value;
+      state.a.b.value;
+      state.c.value;
+    }
+  });
+
+  store.subscribeAction({
+    before(action, state) {
+      action.type;
+      action.payload;
+      state.value;
+      state.a.value;
+      state.a.b.value;
+      state.c.value;
+    },
+    error(action, state, error) {
+      action.type;
+      action.payload;
+      state.value;
+      state.a.value;
+      state.a.b.value;
+      state.c.value;
+      error;
+    }
+  });
+
+  store.subscribeAction({
+    before(action, state) {
+      action.type;
+      action.payload;
+      state.value;
+      state.a.value;
+      state.a.b.value;
+      state.c.value;
+    },
+    after(action, state) {
+      action.type;
+      action.payload;
+      state.value;
+      state.a.value;
+      state.a.b.value;
+      state.c.value;
+    },
+    error(action, state, error) {
+      action.type;
+      action.payload;
+      state.value;
+      state.a.value;
+      state.a.b.value;
+      state.c.value;
+      error;
+    }
+  });
+
+  store.subscribeAction({
+    after(action, state) {
+      action.type;
+      action.payload;
+      state.value;
+      state.a.value;
+      state.a.b.value;
+      state.c.value;
+    }
+  });
+
+  store.subscribeAction({
+    after(action, state) {
+      action.type;
+      action.payload;
+      state.value;
+      state.a.value;
+      state.a.b.value;
+      state.c.value;
+    },
+    error(action, state, error) {
+      action.type;
+      action.payload;
+      state.value;
+      state.a.value;
+      state.a.b.value;
+      state.c.value;
+      error;
+    }
+  });
+
+  store.subscribeAction({
+    error(action, state, error) {
+      action.type;
+      action.payload;
+      state.value;
+      state.a.value;
+      state.a.b.value;
+      state.c.value;
+      error;
+    }
+  });
+
+  store.replaceState({
+    value: 10,
+    a: {
+      value: 20,
+      b: {
+        value: 30
+      }
+    },
+    c: {
+      value: 40
+    }
+  });
+}
+
 namespace RootModule {
   const store = new Vuex.Store({
     state: {
@@ -239,7 +425,7 @@ namespace NestedModules {
     }
   };
 
-  const store = new Vuex.Store<RootState>({
+  const store = new Vuex.Store({
     getters: {
       root: state => state
     },
@@ -250,9 +436,9 @@ namespace NestedModules {
           c: module,
           d: module,
           e: {
-            state: {
+            state: () => ({
               value: 0
-            },
+            }),
             actions: {
               foo(context: ActionStore, payload) {
                 this.state.a;
@@ -263,6 +449,11 @@ namespace NestedModules {
       }
     }
   });
+
+  store.state.a.value;
+  store.state.b.c.value;
+  store.state.b.d.value;
+  store.state.b.e.value;
 }
 
 namespace NamespacedModule {
@@ -332,30 +523,39 @@ namespace NamespacedModule {
 }
 
 namespace RegisterModule {
-  interface RootState {
-    value: number;
-    a?: {
-      value: number;
-      b?: {
-        value: number;
-      }
-    };
-  }
-
-  const store = new Vuex.Store<RootState>({
+  const store = new Vuex.Store({
     state: {
       value: 0
+    },
+    modules: {
+      c: {
+        state: { value: 3 }
+      }
     }
   });
 
   store.registerModule("a", {
-    state: { value: 1 }
+    state: { value: 1 },
+    getters: {
+      foo(state, getters, rootState, rootGetters) {
+        state.value;
+        rootState.value;
+        rootState.c.value;
+      }
+    }
   });
 
   store.hasModule('a')
 
   store.registerModule(["a", "b"], {
-    state: { value: 2 }
+    state: { value: 2 },
+    getters: {
+      foo(state, getters, rootState, rootGetters) {
+        state.value;
+        rootState.value;
+        rootState.c.value;
+      }
+    }
   });
 
   store.registerModule(["a", "b"], {
@@ -411,7 +611,7 @@ namespace HotUpdate {
     }
   };
 
-  const store = new Vuex.Store<RootState>({
+  const store = new Vuex.Store({
     state: {
       value: 0
     } as any,


### PR DESCRIPTION
_DISCLAIMER: The use of [conditional types](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#conditional-types) and [`ReturnType<T>`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#predefined-conditional-types) in this PR requires the user to use at least Typescript 2.8. Right now the use of [generic parameter defaults](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-3.html#generic-parameter-defaults) in helper.d.ts only requires Typescript 2.3._

This PR improves the typings of `Store`. Right now, given code like

```js
let moduleC = {
    state() {
        return {
            valueC: -13
        }
    }
}
let moduleA = {
    state() {
        return ({
            valueA: "6",
        })
    },
    modules: {
        c: moduleC,
    }
}
let moduleB = {
    state: {
        a: 36,
    }
}
let store = new Vuex.Store({
    state: () => ({
        foo: 6
    }),
    modules: {
        a: moduleA,
        b: moduleB,
    }
})
```

would result in the type of `store.state` to only consider the local state in the root. Also `store.state` would be typed as a function and not as its return type. With this PR the type of `store.state` will correspond to

```js
{
    foo: number;
    a: {
        valueA: string;
        c: {
            valueC: number;
        }
    };
    b: {
        a: number;
    };
}
```

### Compatibility
We provided defaults for new generics, therefore one should be able to still use the types as before.

### About older TS versions
There seems to be a strange bug in older versions of Typescript. Sometimes the type of a store differs depending on wheather you use the `{ state() { return {...}}, ... }` or the `{ state: () => ({...}), ... }` syntax. Its not that much of a problem though. We tested the typings in 2.8.4 and the only thing that happens was that the properties are missing, but TS does not throw an error (as long as you don't try to access one of these properties) In newer versions of Typescript everything is fine.