### PR TITLE
fix(types): add lost argument of useStore

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -45,7 +45,7 @@ export declare class Store<S> {
 
 export function createStore<S>(options: StoreOptions<S>): Store<S>;
 
-export function useStore<S = any>(): Store<S>;
+export function useStore<S = any>(key?: string): Store<S>;
 
 export interface Dispatch {
   (type: string, payload?: any, options?: DispatchOptions): Promise<any>;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -45,7 +45,7 @@ export declare class Store<S> {
 
 export function createStore<S>(options: StoreOptions<S>): Store<S>;
 
-export function useStore<S = any>(injectKey?: InjectionKey<Store<any>> | string): Store<S>;
+export function useStore<S = any>(injectKey?: InjectionKey<Store<S>> | string): Store<S>;
 
 export interface Dispatch {
   (type: string, payload?: any, options?: DispatchOptions): Promise<any>;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -15,7 +15,7 @@ export declare class Store<S> {
   readonly state: S;
   readonly getters: any;
 
-  install(app: App, injectKey?: InjectionKey<Store<any>>): void;
+  install(app: App, injectKey?: InjectionKey<Store<any>> | string): void;
 
   replaceState(state: S): void;
 
@@ -45,7 +45,7 @@ export declare class Store<S> {
 
 export function createStore<S>(options: StoreOptions<S>): Store<S>;
 
-export function useStore<S = any>(key?: string): Store<S>;
+export function useStore<S = any>(injectKey?: InjectionKey<Store<any>> | string): Store<S>;
 
 export interface Dispatch {
   (type: string, payload?: any, options?: DispatchOptions): Promise<any>;

--- a/types/test/index.ts
+++ b/types/test/index.ts
@@ -1,3 +1,4 @@
+import { InjectionKey } from "vue";
 import * as Vuex from "../index";
 
 namespace StoreInstance {
@@ -137,6 +138,14 @@ namespace UseStoreFunction {
   interface State {
     a: string
   }
+
+  const key: InjectionKey<string> = Symbol('store')
+
+  const storeWithKey = Vuex.useStore(key)
+  storeWithKey.state.a
+
+  const storeWithKeyString = Vuex.useStore('store')
+  storeWithKeyString.state.a
 
   const storeWithState = Vuex.useStore<State>()
   storeWithState.state.a


### PR DESCRIPTION
This PR adds lost argument `key` to `useStore` function types.
Resolve #1807 