### PR TITLE
docs(typo): fix incorrect createNamespacedHelpers name in ja

### DIFF
--- a/docs/ja/api/README.md
+++ b/docs/ja/api/README.md
@@ -315,7 +315,7 @@ const store = new Vuex.Store({ ...options })
 
   第2引数のオブジェクトのメンバーには関数 `function(commit: function, ...args: any[])` を指定できます。
 
-### createNamespaceHelpers
+### createNamespacedHelpers
 
 - `createNamespacedHelpers(namespace: string): Object`
 


### PR DESCRIPTION

The "d" did not exist at the heading of `createNamespacedHelpers` in ja doc.