### PR TITLE
docs: show mutations in 4.x example also

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -47,6 +47,11 @@ const store = createStore({
     return {
       count: 1
     }
+  },
+  mutations: {
+    increment (state) {
+      state.count++
+    }
   }
 })
 


### PR DESCRIPTION
In the example for Vuex 3.x, mutations have been illustrated. I've added them to the example for 4.x too for consistency.