### PR TITLE
docs: warn about calling unsubscribe (fix #1050)

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -176,13 +176,20 @@ const store = new Vuex.Store({ ...options })
 
 -  `subscribe(handler: Function, options?: Object): Function`
 
-  Subscribe to store mutations. The `handler` is called after every mutation and receives the mutation descriptor and post-mutation state as arguments:
+  Subscribe to store mutations. The `handler` is called after every mutation and receives the mutation descriptor and post-mutation state as arguments.
+
+:::warning WARNING
+A subscription created within a Vue component will remain after the component destroyed. You must call `unsubscribe` to prevent resource leaks.
+:::
 
   ``` js
-  store.subscribe((mutation, state) => {
+  const unsubscribe = store.subscribe((mutation, state) => {
     console.log(mutation.type)
     console.log(mutation.payload)
   })
+
+  // remember to call unsubscribe
+  unsubscribe()
   ```
 
   By default, new handler is added to the end of the chain, so it will be executed after other handlers that were added before. This can be overridden by adding `prepend: true` to `options`, which will add the handler to the beginning of the chain.
@@ -201,13 +208,20 @@ const store = new Vuex.Store({ ...options })
 
   > New in 2.5.0
 
-  Subscribe to store actions. The `handler` is called for every dispatched action and receives the action descriptor and current store state as arguments:
+  Subscribe to store actions. The `handler` is called for every dispatched action and receives the action descriptor and current store state as arguments.
+
+:::warning WARNING
+A subscription created within a Vue component will remain after the component destroyed. You must call `unsubscribe` to prevent resource leaks.
+:::
 
   ``` js
-  store.subscribeAction((action, state) => {
+  const unsubscribe = store.subscribeAction((action, state) => {
     console.log(action.type)
     console.log(action.payload)
   })
+
+  // remember to call unsubscribe
+  unsubscribe()
   ```
 
   By default, new handler is added to the end of the chain, so it will be executed after other handlers that were added before. This can be overridden by adding `prepend: true` to `options`, which will add the handler to the beginning of the chain.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -177,10 +177,7 @@ const store = new Vuex.Store({ ...options })
 -  `subscribe(handler: Function, options?: Object): Function`
 
   Subscribe to store mutations. The `handler` is called after every mutation and receives the mutation descriptor and post-mutation state as arguments.
-
-:::warning WARNING
-A subscription created within a Vue component will remain after the component destroyed. You must call `unsubscribe` to prevent resource leaks.
-:::
+  The `subscribe` method will return an `unsubscribe` function, which should be called when the subscription is no longer needed. For example, when unregistering a Vuex module or before destroying a Vue component.
 
   ``` js
   const unsubscribe = store.subscribe((mutation, state) => {
@@ -198,8 +195,6 @@ A subscription created within a Vue component will remain after the component de
   store.subscribe(handler, { prepend: true })
   ```
 
-  To stop subscribing, call the returned unsubscribe function.
-
   Most commonly used in plugins. [Details](../guide/plugins.md)
 
 ### subscribeAction
@@ -209,10 +204,7 @@ A subscription created within a Vue component will remain after the component de
   > New in 2.5.0
 
   Subscribe to store actions. The `handler` is called for every dispatched action and receives the action descriptor and current store state as arguments.
-
-:::warning WARNING
-A subscription created within a Vue component will remain after the component destroyed. You must call `unsubscribe` to prevent resource leaks.
-:::
+  The `subscribe` method will return an `unsubscribe` function, which should be called when the subscription is no longer needed. For example, when unregistering a Vuex module or before destroying a Vue component.
 
   ``` js
   const unsubscribe = store.subscribeAction((action, state) => {
@@ -229,8 +221,6 @@ A subscription created within a Vue component will remain after the component de
   ``` js
   store.subscribeAction(handler, { prepend: true })
   ```
-
-  To stop subscribing, call the returned unsubscribe function.
 
   > New in 3.1.0
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -177,7 +177,6 @@ const store = new Vuex.Store({ ...options })
 -  `subscribe(handler: Function, options?: Object): Function`
 
   Subscribe to store mutations. The `handler` is called after every mutation and receives the mutation descriptor and post-mutation state as arguments.
-  The `subscribe` method will return an `unsubscribe` function, which should be called when the subscription is no longer needed. For example, when unregistering a Vuex module or before destroying a Vue component.
 
   ``` js
   const unsubscribe = store.subscribe((mutation, state) => {
@@ -185,7 +184,7 @@ const store = new Vuex.Store({ ...options })
     console.log(mutation.payload)
   })
 
-  // remember to call unsubscribe
+  // You may call unsubscribe to stop the subscription
   unsubscribe()
   ```
 
@@ -194,6 +193,8 @@ const store = new Vuex.Store({ ...options })
   ``` js
   store.subscribe(handler, { prepend: true })
   ```
+
+  The `subscribe` method will return an `unsubscribe` function, which should be called when the subscription is no longer needed. For example, you might subscribe to a Vuex Module and unsubscribe when you unregister the module. Or you might call `subscribe` from inside a Vue Component and then destroy the component later. In these cases, you should remember to unsubscribe the subscription manually.
 
   Most commonly used in plugins. [Details](../guide/plugins.md)
 
@@ -212,7 +213,7 @@ const store = new Vuex.Store({ ...options })
     console.log(action.payload)
   })
 
-  // remember to call unsubscribe
+  // You may call unsubscribe to stop the subscription
   unsubscribe()
   ```
 
@@ -221,6 +222,8 @@ const store = new Vuex.Store({ ...options })
   ``` js
   store.subscribeAction(handler, { prepend: true })
   ```
+
+  The `subscribeAction` method will return an `unsubscribe` function, which should be called when the subscription is no longer needed. For example, you might subscribe to a Vuex Module and unsubscribe when you unregister the module. Or you might call `subscribeAction` from inside a Vue Component and then destroy the component later. In these cases, you should remember to unsubscribe the subscription manually.
 
   > New in 3.1.0
 


### PR DESCRIPTION
I added a warning text to the docs about remembering to call `unsubscribe` when subscribing to the store.