### PR TITLE
Check existence of module parent in isRegistered (fix #1850)

### DIFF
--- a/src/module/module-collection.js
+++ b/src/module/module-collection.js
@@ -72,7 +72,11 @@ export default class ModuleCollection {
     const parent = this.get(path.slice(0, -1))
     const key = path[path.length - 1]
 
-    return parent.hasChild(key)
+    if (parent) {
+      return parent.hasChild(key)
+    }
+
+    return false
   }
 }
 

--- a/test/unit/module/module-collection.spec.js
+++ b/test/unit/module/module-collection.spec.js
@@ -81,6 +81,23 @@ describe('ModuleCollection', () => {
     expect(collection.get(['a'])).toBe(undefined)
   })
 
+  it('isRegistered', () => {
+    const collection = new ModuleCollection({})
+
+    collection.register(['a'], {
+      state: { value: true }
+    })
+
+    collection.register(['a', 'b'], {
+      state: { value: false }
+    })
+
+    expect(collection.isRegistered(['a'])).toBe(true)
+    expect(collection.isRegistered(['a', 'b'])).toBe(true)
+    expect(collection.isRegistered(['c'])).toBe(false)
+    expect(collection.isRegistered(['c', 'd'])).toBe(false)
+  })
+
   it('does not unregister initial modules', () => {
     const collection = new ModuleCollection({
       modules: {
@@ -99,19 +116,5 @@ describe('ModuleCollection', () => {
     const collection = new ModuleCollection({})
     collection.unregister(['a'])
     expect(spy).toHaveBeenCalled()
-  })
-
-  it('isRegistered', () => {
-    const collection = new ModuleCollection({})
-    collection.register(['a'], {
-      state: { value: true }
-    })
-    collection.register(['a', 'b'], {
-      state: { value: false }
-    })
-    expect(collection.isRegistered(['a'])).toBe(true)
-    expect(collection.isRegistered(['a', 'b'])).toBe(true)
-    expect(collection.isRegistered(['c'])).toBe(false)
-    expect(collection.isRegistered(['c', 'd'])).toBe(false)
   })
 })

--- a/test/unit/module/module-collection.spec.js
+++ b/test/unit/module/module-collection.spec.js
@@ -100,4 +100,18 @@ describe('ModuleCollection', () => {
     collection.unregister(['a'])
     expect(spy).toHaveBeenCalled()
   })
+
+  it('isRegistered', () => {
+    const collection = new ModuleCollection({})
+    collection.register(['a'], {
+      state: { value: true }
+    })
+    collection.register(['a', 'b'], {
+      state: { value: false }
+    })
+    expect(collection.isRegistered(['a'])).toBe(true)
+    expect(collection.isRegistered(['a', 'b'])).toBe(true)
+    expect(collection.isRegistered(['c'])).toBe(false)
+    expect(collection.isRegistered(['c', 'd'])).toBe(false)
+  })
 })

--- a/test/unit/modules.spec.js
+++ b/test/unit/modules.spec.js
@@ -91,6 +91,18 @@ describe('Modules', () => {
       expect(store.hasModule('bonjour')).toBe(false)
     })
 
+    it('dynamic module existance test with nested modules', () => {
+      const store = new Vuex.Store({})
+
+      store.registerModule('a', {})
+      store.registerModule(['a', 'b'], {})
+
+      expect(store.hasModule(['a'])).toBe(true)
+      expect(store.hasModule(['a', 'b'])).toBe(true)
+      expect(store.hasModule(['c'])).toBe(false)
+      expect(store.hasModule(['c', 'd'])).toBe(false)
+    })
+
     it('dynamic module registration preserving hydration', () => {
       const store = new Vuex.Store({})
       store.replaceState({ a: { foo: 'state' }})


### PR DESCRIPTION
This PR fixes issue #1850 .

If you call `store.hasModule()` with an array where none of the modules or submodules are registered in the store, an error is thrown instead of returning false:

```
TypeError: Cannot read property 'hasChild' of undefined
        at ModuleCollection.isRegistered (/node_modules/vuex/dist/vuex.common.js:291:17)
        at Store.hasModule (/node_modules/vuex/dist/vuex.common.js:611:24)
```

