### PR TITLE
feat(types): adding logger type for logger plugin

### DIFF
--- a/types/logger.d.ts
+++ b/types/logger.d.ts
@@ -1,5 +1,10 @@
 import { Payload, Plugin } from "./index";
 
+interface Logger extends Partial<Pick<Console, 'groupCollapsed' | 'group' | 'groupEnd'>> {
+  log(message: string, colour: string, action: any): void;
+  log(message: string): void;
+}
+
 export interface LoggerOption<S> {
   collapsed?: boolean;
   filter?: <P extends Payload>(mutation: P, stateBefore: S, stateAfter: S) => boolean;
@@ -9,6 +14,7 @@ export interface LoggerOption<S> {
   actionTransformer?: <P extends Payload>(action: P) => any;
   logMutations?: boolean;
   logActions?: boolean;
+  logger?: Logger;
 }
 
 export default function createLogger<S>(option?: LoggerOption<S>): Plugin<S>;

--- a/types/test/index.ts
+++ b/types/test/index.ts
@@ -437,10 +437,17 @@ namespace Plugins {
     });
   }
 
+  class MyLogger {
+    log(message: string) {
+       console.log(message);
+    }
+  }
+
   const logger = Vuex.createLogger<{ value: number }>({
     collapsed: true,
     transformer: state => state.value,
-    mutationTransformer: (mutation: { type: string }) => mutation.type
+    mutationTransformer: (mutation: { type: string }) => mutation.type,
+    logger: new MyLogger()
   });
 
   const store = new Vuex.Store<{ value: number }>({


### PR DESCRIPTION
* createLogger options takes in logger which by default is console but
can be overridden with own logger.
* Adding Ilogger for logger options params which expects log method to
be implemented