### PR TITLE
Make contributions easier via automating the dev setup.

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,21 @@
+tasks:
+  - name: Examples 
+    init: | 
+      yarn install  
+      gp sync-done install
+      yarn build
+    command: |
+      export PORT="8000"
+      yarn dev
+
+  - name: Docs
+    init: |
+      gp sync-await install
+    command: yarn docs
+    openMode: split-right
+
+ports:
+  - port: 8000
+    onOpen: open-preview 
+  - port: 8080
+    onOpen: open-preview

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Vuex [![Build Status](https://circleci.com/gh/vuejs/vuex/tree/dev.png?style=shield)](https://circleci.com/gh/vuejs/vuex)
+# Vuex [![Build Status](https://circleci.com/gh/vuejs/vuex/tree/dev.png?style=shield)](https://circleci.com/gh/vuejs/vuex) [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/from-referrer/)
 
 > Centralized State Management for Vue.js.
 


### PR DESCRIPTION
Hi.

I work for Gitpod. This PR adds gitpod config to the repo to make contributions easier for newcomers i.e with a single click it will launch a workspace and automatically:

- clone the `vuex` repo.
- install the dependencies.
- run `yarn dev` to serve the examples.
- run `yarn docs` to start the vuepress sever.

This can be helpful for beginners i.e they can start coding instantly without setting anything up.

You can give it a try on my fork of the repo via the following link:

https://gitpod.io/#https://github.com/nisarhassan12/vuex

This is how it looks:

![image](https://user-images.githubusercontent.com/46004116/96831387-6d64d600-1456-11eb-8d18-2a04a12f7e95.png)
