### PR TITLE
test: todomvc case failed in windows and some linux os (#1899)

### DIFF
--- a/test/e2e/todomvc.spec.js
+++ b/test/e2e/todomvc.spec.js
@@ -120,7 +120,7 @@ describe('e2e/todomvc', () => {
     expect(await isFocused('.todo:nth-child(1) .edit')).toBe(true)
     await clearValue('.todo:nth-child(1) .edit')
     await setValue('.todo:nth-child(1) .edit', 'edited!')
-    await click('footer') // blur
+    await click('.todo-count') // blur
     expect(await count('.todo.editing')).toBe(0)
     expect(await text('.todo:nth-child(1) label')).toBe('edited!')
 


### PR DESCRIPTION
As `clear-completed button`  is part of `footer`, although we expect `await click('footer')` will trigger the `footer` element, however it actually triggered the `clear-completed button`, so the next asserts will failed. 4.0 branch has the same problem.
https://github.com/vuejs/vuex/blob/c9dbb13d4138d0e7d82d103dd3275fc18fa72d28/test/e2e/todomvc.spec.js#L123-L125

change click `footer` to `.todo-count` will make sure test cases pass, which could fix #1899.