### PR TITLE
Add support for preserveState options

### DIFF
--- a/docs/guide/modules.md
+++ b/docs/guide/modules.md
@@ -321,6 +321,10 @@ It may be likely that you want to preserve the previous state when registering a
 
 When you set `preserveState: true`, the module is registered, actions, mutations and getters are added to the store, but the state is not. It's assumed that your store state already contains state for that module and you don't want to overwrite it.
 
+If you want state to be preserved only if the existing state actually exists, you can set the `preserveStateType` to `existing`. In this case, the state from the module will be registered if the existing state does not exist.
+
+You can also set `preserveStateType` to `mergeReplaceArrays` or `mergeConcatArrays`, to merge the existing state with the module state using `deepmerge`, either by replacing arrays or combining them. Individual keys from the existing state will overwrite the default ones from the module.
+
 ## Module Reuse
 
 Sometimes we may need to create multiple instances of a module, for example:

--- a/package.json
+++ b/package.json
@@ -91,5 +91,8 @@
     "webpack": "^4.43.0",
     "webpack-dev-middleware": "^3.7.2",
     "webpack-hot-middleware": "^2.25.0"
+  },
+  "dependencies": {
+    "deepmerge": "^4.2.2"
   }
 }

--- a/test/unit/modules.spec.js
+++ b/test/unit/modules.spec.js
@@ -124,6 +124,60 @@ describe('Modules', () => {
       store.commit('a/foo')
       expect(mutationSpy).toHaveBeenCalled()
     })
+
+    it('dynamic module registration ignoring hydration if it does not exist', () => {
+      const store = new Vuex.Store({})
+
+      store.registerModule('test', {
+        namespaced: true,
+        state: () => ({ data: '12345' })
+      }, { preserveState: true, preserveStateType: 'existing' })
+
+      expect(store.state.test.data).toBe('12345')
+    })
+
+    it('dynamic module registration merging hydration', () => {
+      const store = new Vuex.Store({})
+      store.replaceState({ test: {
+        foo: 'hello'
+      }})
+
+      store.registerModule('test', {
+        namespaced: true,
+        state: () => ({ bar: 'world' })
+      }, { preserveState: true, preserveStateType: 'mergeReplaceArrays' })
+
+      expect(store.state.test.foo).toBe('hello')
+      expect(store.state.test.bar).toBe('world')
+    })
+
+    it('dynamic module registration merging hydration by replacing arrays', () => {
+      const store = new Vuex.Store({})
+      store.replaceState({ test: {
+        data: ['hello', 'world']
+      }})
+
+      store.registerModule('test', {
+        namespaced: true,
+        state: () => ({ data: ['foo', 'bar'] })
+      }, { preserveState: true, preserveStateType: 'mergeReplaceArrays' })
+
+      expect(store.state.test.data).toEqual(['hello', 'world'])
+    })
+
+    it('dynamic module registration merging hydration by concating arrays', () => {
+      const store = new Vuex.Store({})
+      store.replaceState({ test: {
+        data: ['hello', 'world']
+      }})
+
+      store.registerModule('test', {
+        namespaced: true,
+        state: () => ({ data: ['foo', 'bar'] })
+      }, { preserveState: true, preserveStateType: 'mergeConcatArrays' })
+
+      expect(store.state.test.data).toEqual(['foo', 'bar', 'hello', 'world'])
+    })
   })
 
   // #524

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -131,6 +131,7 @@ export interface Module<S, R> {
 
 export interface ModuleOptions {
   preserveState?: boolean;
+  preserveStateType?: 'always' | 'existing' | 'mergeReplaceArrays' | 'mergeConcatArrays';
 }
 
 export interface GetterTree<S, R> {


### PR DESCRIPTION
This adds support for specifying options to `preserveState`, allowing to only skip default module state registration when the state already exists or to merge the existing state with the state from the module. It closes #1675.