### PR TITLE
fix: Add optional to getter arguments

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -115,7 +115,7 @@ export interface ActionObject<S, R> {
   handler: ActionHandler<S, R>;
 }
 
-export type Getter<S, R> = (state: S, getters: any, rootState: R, rootGetters: any) => any;
+export type Getter<S, R> = (state: S, getters?: any, rootState?: R, rootGetters?: any) => any;
 export type Action<S, R> = ActionHandler<S, R> | ActionObject<S, R>;
 export type Mutation<S> = (state: S, payload?: any) => any;
 export type Plugin<S> = (store: Store<S>) => any;


### PR DESCRIPTION
As mentioned in: https://github.com/vuejs/vuex/issues/1467 

Just making sure the arguments on getters are aligned with the actual usage, otherwise any typescript user is enquire to pass all arguments even if they are not really required:

Example:
`getters.bar(state, getters, state, {})` => `getters.bar(state)` works equally for Vuex module level