### PR TITLE
feat(types): strictly typed

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "semver": "^7.3.4",
     "start-server-and-test": "^1.12.0",
     "todomvc-app-css": "^2.3.0",
-    "typescript": "^4.1.3",
+    "typescript": "^4.2.2",
     "vitepress": "^0.11.5",
     "vue": "^3.0.5",
     "vue-loader": "^16.1.2",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,31 +3,82 @@ import { App, WatchOptions, InjectionKey } from "vue";
 // augment typings of Vue.js
 import "./vue";
 
-import { mapState, mapMutations, mapGetters, mapActions, createNamespacedHelpers } from "./helpers";
+import {
+  mapState,
+  mapMutations,
+  mapGetters,
+  mapActions,
+  createNamespacedHelpers,
+} from "./helpers";
 import { createLogger } from "./logger";
 
 export * from "./helpers";
 export * from "./logger";
 
-export declare class Store<S> {
-  constructor(options: StoreOptions<S>);
+type YieldState<S, T extends ModuleTree<S> | undefined> = (S extends () => any
+  ? ReturnType<S>
+  : S) &
+  (T extends ModuleTree<S>
+    ? {
+        [K in keyof T]: T extends ModuleTree<S>
+          ? YieldState<
+              T[K]["state"],
+              T[K] extends { modules: object } ? T[K]["modules"] : {}
+            >
+          : never;
+      }
+    : {});
 
-  readonly state: S;
-  readonly getters: any;
+type YieldGetter<
+  SO extends StoreOptions<any>,
+  G = {} extends ExtractObjects<SO, "getters">
+    ? any
+    : ExtractObjects<SO, "getters">
+> = {
+  [K in keyof G]: G[K] extends (...args: any) => any ? ReturnType<G[K]> : any;
+};
+
+export declare class Store<
+  _,
+  SO extends StoreOptions<any> = StoreOptions<_>,
+  S = SO["state"] extends _ ? SO["state"] : _
+> {
+  constructor(options: SO);
+
+  readonly state: YieldState<S, SO["modules"]>;
+  readonly getters: YieldGetter<SO>;
 
   install(app: App, injectKey?: InjectionKey<Store<any>> | string): void;
 
-  replaceState(state: S): void;
+  replaceState(state: S): Store<S, SO>;
 
-  dispatch: Dispatch;
-  commit: Commit;
+  dispatch: Dispatch<SO>;
+  commit: Commit<SO>;
 
-  subscribe<P extends MutationPayload>(fn: (mutation: P, state: S) => any, options?: SubscribeOptions): () => void;
-  subscribeAction<P extends ActionPayload>(fn: SubscribeActionOptions<P, S>, options?: SubscribeOptions): () => void;
-  watch<T>(getter: (state: S, getters: any) => T, cb: (value: T, oldValue: T) => void, options?: WatchOptions): () => void;
+  subscribe<P extends MutationPayload>(
+    fn: (mutation: P, state: S) => any,
+    options?: SubscribeOptions
+  ): () => void;
+  subscribeAction<P extends ActionPayload>(
+    fn: SubscribeActionOptions<P, S>,
+    options?: SubscribeOptions
+  ): () => void;
+  watch<T>(
+    getter: (state: S, getters: any) => T,
+    cb: (value: T, oldValue: T) => void,
+    options?: WatchOptions
+  ): () => void;
 
-  registerModule<T>(path: string, module: Module<T, S>, options?: ModuleOptions): void;
-  registerModule<T>(path: string[], module: Module<T, S>, options?: ModuleOptions): void;
+  registerModule<T>(
+    path: string,
+    module: Module<T, S>,
+    options?: ModuleOptions
+  ): void;
+  registerModule<T>(
+    path: string[],
+    module: Module<T, S>,
+    options?: ModuleOptions
+  ): void;
 
   unregisterModule(path: string): void;
   unregisterModule(path: string[]): void;
@@ -45,18 +96,82 @@ export declare class Store<S> {
 
 export const storeKey: string;
 
-export function createStore<S>(options: StoreOptions<S>): Store<S>;
+export function createStore<S, SO extends StoreOptions<any> = StoreOptions<S>>(
+  options: SO
+): Store<SO["state"], SO>;
 
-export function useStore<S = any>(injectKey?: InjectionKey<Store<S>> | string): Store<S>;
+export function useStore<
+  S = any,
+  SO extends StoreOptions<any> = StoreOptions<S>
+>(injectKey?: InjectionKey<Store<S, SO>> | string): Store<S, SO>;
 
-export interface Dispatch {
-  (type: string, payload?: any, options?: DispatchOptions): Promise<any>;
-  <P extends Payload>(payloadWithType: P, options?: DispatchOptions): Promise<any>;
+type StrictString<T> = T extends string ? T : never;
+
+type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
+  k: infer I
+) => void
+  ? I
+  : never;
+
+type ExtractObjects<
+  T,
+  S extends string = "actions",
+  P extends string = ""
+> = (T extends {
+  [_ in S]: infer O;
+}
+  ? { [K in keyof O as `${P}${StrictString<K>}`]: O[K] }
+  : {}) &
+  (T extends {
+    modules: infer O;
+  }
+    ? UnionToIntersection<
+        {
+          [K in keyof O]: ExtractObjects<O[K], S, `${P}${StrictString<K>}/`>;
+        }[keyof O]
+      >
+    : {});
+
+export interface Dispatch<
+  SO extends StoreOptions<any> = StoreOptions<any>,
+  AT = StoreOptions<any> extends SO ? any : ExtractObjects<SO, "actions">
+> {
+  <T extends keyof AT, A extends AT[T]>(
+    type: T,
+    payload?: A extends ActionHandler<any, any>
+      ? Parameters<A>[1]
+      : A extends ActionObject<any, any>
+      ? Parameters<A["handler"]>[1]
+      : undefined,
+    options?: DispatchOptions
+  ): A extends ActionHandler<any, any>
+    ? ReturnType<A>
+    : A extends ActionObject<any, any>
+    ? ReturnType<A["handler"]>
+    : Promise<any>;
+  <T extends keyof AT, A extends AT[T], P extends Payload<T>>(
+    payloadWithType: P,
+    options?: DispatchOptions
+  ): A extends ActionHandler<any, any>
+    ? ReturnType<A>
+    : A extends ActionObject<any, any>
+    ? ReturnType<A["handler"]>
+    : Promise<any>;
 }
 
-export interface Commit {
-  (type: string, payload?: any, options?: CommitOptions): void;
-  <P extends Payload>(payloadWithType: P, options?: CommitOptions): void;
+export interface Commit<
+  SO extends StoreOptions<any> = StoreOptions<any>,
+  MT = StoreOptions<any> extends SO ? any : ExtractObjects<SO, "mutations">
+> {
+  <T extends keyof MT, M extends MT[T]>(
+    type: T,
+    payload?: M extends Mutation<any> ? Parameters<M>[1] : undefined,
+    options?: CommitOptions
+  ): void;
+  <T extends keyof MT, P extends Payload<T>>(
+    payloadWithType: P,
+    options?: CommitOptions
+  ): void;
 }
 
 export interface ActionContext<S, R> {
@@ -68,8 +183,8 @@ export interface ActionContext<S, R> {
   rootGetters: any;
 }
 
-export interface Payload {
-  type: string;
+export interface Payload<T = string> {
+  type: T;
 }
 
 export interface MutationPayload extends Payload {
@@ -81,11 +196,15 @@ export interface ActionPayload extends Payload {
 }
 
 export interface SubscribeOptions {
-  prepend?: boolean
+  prepend?: boolean;
 }
 
 export type ActionSubscriber<P, S> = (action: P, state: S) => any;
-export type ActionErrorSubscriber<P, S> = (action: P, state: S, error: Error) => any;
+export type ActionErrorSubscriber<P, S> = (
+  action: P,
+  state: S,
+  error: Error
+) => any;
 
 export interface ActionSubscribersObject<P, S> {
   before?: ActionSubscriber<P, S>;
@@ -93,7 +212,9 @@ export interface ActionSubscribersObject<P, S> {
   error?: ActionErrorSubscriber<P, S>;
 }
 
-export type SubscribeActionOptions<P, S> = ActionSubscriber<P, S> | ActionSubscribersObject<P, S>;
+export type SubscribeActionOptions<P, S> =
+  | ActionSubscriber<P, S>
+  | ActionSubscribersObject<P, S>;
 
 export interface DispatchOptions {
   root?: boolean;
@@ -115,13 +236,22 @@ export interface StoreOptions<S> {
   devtools?: boolean;
 }
 
-export type ActionHandler<S, R> = (this: Store<R>, injectee: ActionContext<S, R>, payload?: any) => any;
+export type ActionHandler<S, R> = (
+  this: Store<R>,
+  injectee: ActionContext<S, R>,
+  payload?: any
+) => any;
 export interface ActionObject<S, R> {
   root?: boolean;
   handler: ActionHandler<S, R>;
 }
 
-export type Getter<S, R> = (state: S, getters: any, rootState: R, rootGetters: any) => any;
+export type Getter<S, R> = (
+  state: S,
+  getters: any,
+  rootState: R,
+  rootGetters: any
+) => any;
 export type Action<S, R> = ActionHandler<S, R> | ActionObject<S, R>;
 export type Mutation<S> = (state: S, payload?: any) => any;
 export type Plugin<S> = (store: Store<S>) => any;
@@ -157,11 +287,11 @@ export interface ModuleTree<R> {
 
 declare const _default: {
   Store: typeof Store;
-  mapState: typeof mapState,
-  mapMutations: typeof mapMutations,
-  mapGetters: typeof mapGetters,
-  mapActions: typeof mapActions,
-  createNamespacedHelpers: typeof createNamespacedHelpers,
-  createLogger: typeof createLogger
+  mapState: typeof mapState;
+  mapMutations: typeof mapMutations;
+  mapGetters: typeof mapGetters;
+  mapActions: typeof mapActions;
+  createNamespacedHelpers: typeof createNamespacedHelpers;
+  createLogger: typeof createLogger;
 };
 export default _default;

--- a/types/logger.d.ts
+++ b/types/logger.d.ts
@@ -1,13 +1,18 @@
-import { Payload, Plugin } from "./index";
+import { Payload, Plugin, StoreOptions } from "./index";
 
-interface Logger extends Partial<Pick<Console, 'groupCollapsed' | 'group' | 'groupEnd'>> {
+interface Logger
+  extends Partial<Pick<Console, "groupCollapsed" | "group" | "groupEnd">> {
   log(message: string, color: string, payload: any): void;
   log(message: string): void;
 }
 
 export interface LoggerOption<S> {
   collapsed?: boolean;
-  filter?: <P extends Payload>(mutation: P, stateBefore: S, stateAfter: S) => boolean;
+  filter?: <P extends Payload>(
+    mutation: P,
+    stateBefore: S,
+    stateAfter: S
+  ) => boolean;
   transformer?: (state: S) => any;
   mutationTransformer?: <P extends Payload>(mutation: P) => any;
   actionFilter?: <P extends Payload>(action: P, state: S) => boolean;
@@ -17,4 +22,6 @@ export interface LoggerOption<S> {
   logger?: Logger;
 }
 
-export function createLogger<S>(option?: LoggerOption<S>): Plugin<S>;
+export function createLogger<S>(
+  option?: LoggerOption<S>
+): Plugin<S>;

--- a/types/test/index.ts
+++ b/types/test/index.ts
@@ -4,31 +4,47 @@ import * as Vuex from "../index";
 namespace StoreInstance {
   const store = new Vuex.Store({
     state: {
-      value: 0
+      value: 0,
+    },
+    mutations: {
+      foo(state, payload: {amount: number}){
+        state.value = payload.amount
+      }
+    },
+    actions: {
+      async foo({commit}, payload: {amount: number}) {
+        commit('hoge', payload.amount)
+      }
     }
   });
 
   store.state.value;
-  store.getters.foo;
 
+  store.dispatch("foo", { amount: 1 });
   store.dispatch("foo", { amount: 1 }).then(() => {});
-  store.dispatch({
-    type: "foo",
-    amount: 1
-  }).then(() => {});
+  store
+    .dispatch({
+      type: "foo",
+      amount: 1,
+    })
+    .then(() => {});
 
   store.commit("foo", { amount: 1 });
   store.commit({
     type: "foo",
-    amount: 1
+    amount: 1,
   });
 
-  store.watch(state => state.value, value => {
-    value = value + 1;
-  }, {
-    immediate: true,
-    deep: true
-  });
+  store.watch(
+    (state) => state.value,
+    (value) => {
+      value = value + 1;
+    },
+    {
+      immediate: true,
+      deep: true,
+    }
+  );
 
   store.subscribe((mutation, state) => {
     mutation.type;
@@ -49,34 +65,7 @@ namespace StoreInstance {
       action.type;
       action.payload;
       state.value;
-    }
-  });
-
-  store.subscribeAction({
-    before(action, state) {
-      action.type;
-      action.payload;
-      state.value;
     },
-    after(action, state) {
-      action.type;
-      action.payload;
-      state.value;
-    }
-  });
-
-  store.subscribeAction({
-    before(action, state) {
-      action.type;
-      action.payload;
-      state.value;
-    },
-    error(action, state, error) {
-      action.type;
-      action.payload;
-      state.value;
-      error;
-    }
   });
 
   store.subscribeAction({
@@ -90,12 +79,39 @@ namespace StoreInstance {
       action.payload;
       state.value;
     },
+  });
+
+  store.subscribeAction({
+    before(action, state) {
+      action.type;
+      action.payload;
+      state.value;
+    },
     error(action, state, error) {
       action.type;
       action.payload;
       state.value;
       error;
-    }
+    },
+  });
+
+  store.subscribeAction({
+    before(action, state) {
+      action.type;
+      action.payload;
+      state.value;
+    },
+    after(action, state) {
+      action.type;
+      action.payload;
+      state.value;
+    },
+    error(action, state, error) {
+      action.type;
+      action.payload;
+      state.value;
+      error;
+    },
   });
 
   store.subscribeAction({
@@ -103,7 +119,7 @@ namespace StoreInstance {
       action.type;
       action.payload;
       state.value;
-    }
+    },
   });
 
   store.subscribeAction({
@@ -117,7 +133,7 @@ namespace StoreInstance {
       action.payload;
       state.value;
       error;
-    }
+    },
   });
 
   store.subscribeAction({
@@ -126,7 +142,7 @@ namespace StoreInstance {
       action.payload;
       state.value;
       error;
-    }
+    },
   });
 
   store.subscribeAction({}, { prepend: true });
@@ -136,80 +152,80 @@ namespace StoreInstance {
 
 namespace UseStoreFunction {
   interface State {
-    a: string
+    a: string;
   }
 
-  const key: InjectionKey<string> = Symbol('store')
+  const key: InjectionKey<string> = Symbol("store");
 
-  const storeWithKey = Vuex.useStore(key)
-  storeWithKey.state.a
+  const storeWithKey = Vuex.useStore(key);
+  storeWithKey.state.a;
 
-  const storeWithKeyString = Vuex.useStore('store')
-  storeWithKeyString.state.a
+  const storeWithKeyString = Vuex.useStore("store");
+  storeWithKeyString.state.a;
 
-  const storeWithState = Vuex.useStore<State>()
-  storeWithState.state.a
+  const storeWithState = Vuex.useStore<State>();
+  storeWithState.state.a;
 
-  const storeAsAny = Vuex.useStore()
-  storeAsAny.state.a
+  const storeAsAny = Vuex.useStore();
+  storeAsAny.state.a;
 }
 
 namespace RootModule {
   const store = new Vuex.Store({
     state: {
-      value: 0
+      value: 0,
     },
     getters: {
-      count: state => state.value,
-      plus10: (_, { count }) => count + 10
+      count: (state) => state.value,
+      plus10: (_, { count }) => count + 10,
     },
     actions: {
-      foo ({ state, getters, dispatch, commit }, payload) {
+      foo({ state, getters, dispatch, commit }, payload) {
         this.state.value;
         state.value;
         getters.count;
         dispatch("bar", {});
         commit("bar", {});
-      }
+      },
     },
     mutations: {
-      bar (state, payload) {}
+      bar(state, payload) {},
     },
     strict: true,
-    devtools: true
+    devtools: true,
   });
 }
 
 namespace RootDefaultModule {
   const store = new Vuex.default.Store({
     state: {
-      value: 0
+      value: 0,
     },
     getters: {
-      count: state => state.value,
-      plus10: (_, { count }) => count + 10
+      count: (state) => state.value,
+      plus10: (_, { count }) => count + 10,
     },
     actions: {
-      foo ({ state, getters, dispatch, commit }, payload) {
+      foo({ state, getters, dispatch, commit }, payload) {
         this.state.value;
         state.value;
         getters.count;
         dispatch("bar", {});
         commit("bar", {});
-      }
+      },
     },
     mutations: {
-      bar (state, payload) {}
+      bar(state, payload) {},
     },
-    strict: true
+    strict: true,
   });
 }
 
 namespace InitialStateFunction {
   const store = new Vuex.Store({
     state: () => ({
-      value: 1
-    })
+      value: 1,
+    }),
   });
   const n: number = store.state.value;
 }
@@ -225,21 +241,21 @@ namespace NestedModules {
       };
       d: {
         value: number;
-      },
+      };
       e: {
         value: number;
-      }
+      };
     };
   }
 
-  type ActionStore = Vuex.ActionContext<{ value: number }, RootState>
+  type ActionStore = Vuex.ActionContext<{ value: number }, RootState>;
 
   const module = {
     state: {
-      value: 0
+      value: 0,
     },
     actions: {
-      foo (
+      foo(
         { state, getters, dispatch, commit, rootState }: ActionStore,
         payload: { amount: number }
       ) {
@@ -248,18 +264,18 @@ namespace NestedModules {
         rootState.b.c.value;
         dispatch("bar", {});
         commit("bar", payload);
-      }
+      },
     },
     mutations: {
-      bar (state: { value: number }, payload: { amount: number }) {
+      bar(state: { value: number }, payload: { amount: number }) {
         state.value += payload.amount;
-      }
-    }
+      },
+    },
   };
 
   const store = new Vuex.Store<RootState>({
     getters: {
-      root: state => state
+      root: (state) => state,
     },
     modules: {
       a: module,
@@ -269,17 +285,17 @@ namespace NestedModules {
           d: module,
           e: {
             state: {
-              value: 0
+              value: 0,
             },
             actions: {
               foo(context: ActionStore, payload) {
                 this.state.a;
-              }
-            }
-          }
-        }
-      }
-    }
+              },
+            },
+          },
+        },
+      },
+    },
   });
 }
 
@@ -287,13 +303,13 @@ namespace NamespacedModule {
   const store = new Vuex.Store({
     state: { value: 0 },
     getters: {
-      rootValue: state => state.value
+      rootValue: (state) => state.value,
     },
     actions: {
-      foo () {}
+      foo() {},
     },
     mutations: {
-      foo () {}
+      foo() {},
     },
     modules: {
       a: {
@@ -302,32 +318,32 @@ namespace NamespacedModule {
         actions: {
           test: {
             root: true,
-            handler ({ dispatch }) {
-              dispatch('foo')
-            }
+            handler({ dispatch }) {
+              dispatch("foo");
+            },
           },
           test2: {
-            handler ({ dispatch }) {
-              dispatch('foo')
-            }
-          }
+            handler({ dispatch }) {
+              dispatch("foo");
+            },
+          },
         },
         modules: {
           b: {
-            state: { value: 2 }
+            state: { value: 2 },
           },
           c: {
             namespaced: true,
             state: { value: 3 },
             getters: {
               constant: () => 10,
-              count (state, getters, rootState, rootGetters) {
+              count(state, getters, rootState, rootGetters) {
                 getters.constant;
                 rootGetters.rootValue;
-              }
+              },
             },
             actions: {
-              test ({ dispatch, commit, getters, rootGetters }) {
+              test({ dispatch, commit, getters, rootGetters }) {
                 getters.constant;
                 rootGetters.rootValue;
 
@@ -337,16 +353,24 @@ namespace NamespacedModule {
                 commit("foo");
                 commit("foo", null, { root: true });
               },
-              foo () {}
+              foo() {},
             },
             mutations: {
-              foo () {}
-            }
-          }
-        }
-      }
-    }
+              foo() {},
+            },
+          },
+        },
+      },
+    },
   });
+  store.dispatch("a/c/foo")
+  store.dispatch("a/c/test")
+  store.dispatch("a/test")
+  store.dispatch("a/test2")
+  store.dispatch("foo")
+
+  store.commit("a/c/foo")
+  store.commit("foo")
 }
 
 namespace RegisterModule {
@@ -356,31 +380,35 @@ namespace RegisterModule {
       value: number;
       b?: {
         value: number;
-      }
+      };
     };
   }
 
   const store = new Vuex.Store<RootState>({
     state: {
-      value: 0
-    }
+      value: 0,
+    },
   });
 
   store.registerModule("a", {
-    state: { value: 1 }
+    state: { value: 1 },
   });
 
-  store.hasModule('a')
+  store.hasModule("a");
 
   store.registerModule(["a", "b"], {
-    state: { value: 2 }
+    state: { value: 2 },
   });
 
-  store.registerModule(["a", "b"], {
-    state: { value: 2 }
-  }, { preserveState: true });
+  store.registerModule(
+    ["a", "b"],
+    {
+      state: { value: 2 },
+    },
+    { preserveState: true }
+  );
 
-  store.hasModule(['a', 'b'])
+  store.hasModule(["a", "b"]);
 
   store.unregisterModule(["a", "b"]);
   store.unregisterModule("a");
@@ -394,61 +422,61 @@ namespace HotUpdate {
         value: number;
       };
     };
-  };
+  }
 
-  type ActionStore = Vuex.ActionContext<{ value: number }, RootState>
+  type ActionStore = Vuex.ActionContext<{ value: number }, RootState>;
 
   const getters = {
-    rootValue: (state: RootState) => state.value
+    rootValue: (state: RootState) => state.value,
   };
 
   const actions = {
-    foo (store: ActionStore, payload: number) {}
+    foo(store: ActionStore, payload: number) {},
   };
 
   const mutations = {
-    bar (state: { value: number }, payload: number) {}
+    bar(state: { value: number }, payload: number) {},
   };
 
   const module = {
     state: {
-      value: 0
+      value: 0,
     },
     getters: {
-      count: (state: { value: number }) => state.value
+      count: (state: { value: number }) => state.value,
     },
     actions,
-    mutations
+    mutations,
   };
 
   const modules = {
     a: {
       modules: {
-        b: module
-      }
-    }
+        b: module,
+      },
+    },
   };
 
   const store = new Vuex.Store<RootState>({
     state: {
-      value: 0
+      value: 0,
     } as any,
     getters,
     actions,
     mutations,
-    modules
+    modules,
   });
 
   store.hotUpdate({
     getters,
     actions,
     mutations,
-    modules
+    modules,
   });
 }
 
 namespace Plugins {
-  function plugin (store: Vuex.Store<{ value: number }>) {
+  function plugin(store: Vuex.Store<{ value: number }>) {
     store.subscribe((mutation, state) => {
       mutation.type;
       state.value;
@@ -457,21 +485,21 @@ namespace Plugins {
 
   class MyLogger {
     log(message: string) {
-       console.log(message);
+      console.log(message);
     }
   }
 
   const logger = Vuex.createLogger<{ value: number }>({
     collapsed: true,
-    transformer: state => state.value,
+    transformer: (state) => state.value,
     mutationTransformer: (mutation: { type: string }) => mutation.type,
-    logger: new MyLogger()
+    logger: new MyLogger(),
   });
 
   const store = new Vuex.Store<{ value: number }>({
     state: {
-      value: 0
+      value: 0,
     },
-    plugins: [plugin, logger]
+    plugins: [plugin, logger],
   });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8413,10 +8413,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
-  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
+typescript@^4.2.2:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
+  integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
Using StoreObject instead of State allows for more
type-safe calls to the Vuex API from client.

* `store.dispatch()`, `store.commit()` has namespaced-typed params and their payloads
  * the params links to definition on VS Code
* The inside of StoreObject-calls(ex,  commit()) may have
  `any` type
* mapXxx() are not changed.
* Not supported `root`, `namespaced` flags 

![4f3d2b20c56f96ba1e23a6b9a77c60e7](https://user-images.githubusercontent.com/1287296/111993383-e8dbc800-8b59-11eb-8749-7843ffb15084.gif)
![34510fb278105f5d3e755a367be76eeb](https://user-images.githubusercontent.com/1287296/111995920-d8791c80-8b5c-11eb-9597-87c8e4e3694c.gif)

and changed code formats.

# Please see 
* the naming( because of poor English skill..)
* formats ( default prettier format attached )
* some omissions (don't know well whole Vuex codes)