### PR TITLE
feat: useXXX helpers (issue #1725)

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -13,9 +13,9 @@ sidebar: auto
   Creates a new store.
 
   ```js
-  import { createStore } from 'vuex'
+  import { createStore } from "vuex";
 
-  const store = createStore({ ...options })
+  const store = createStore({ ...options });
   ```
 
 ## Store Constructor Options
@@ -44,12 +44,12 @@ sidebar: auto
 
   ```js
   {
-    state,      // same as `store.state`, or local state if in modules
-    rootState,  // same as `store.state`, only in modules
-    commit,     // same as `store.commit`
-    dispatch,   // same as `store.dispatch`
-    getters,    // same as `store.getters`, or local getters if in modules
-    rootGetters // same as `store.getters`, only in modules
+    state, // same as `store.state`, or local state if in modules
+      rootState, // same as `store.state`, only in modules
+      commit, // same as `store.commit`
+      dispatch, // same as `store.dispatch`
+      getters, // same as `store.getters`, or local getters if in modules
+      rootGetters; // same as `store.getters`, only in modules
   }
   ```
 
@@ -130,7 +130,7 @@ sidebar: auto
 
   ```js
   {
-    devtools: false
+    devtools: false;
   }
   ```
 
@@ -152,122 +152,122 @@ sidebar: auto
 
 ### commit
 
--  `commit(type: string, payload?: any, options?: Object)`
--  `commit(mutation: Object, options?: Object)`
+- `commit(type: string, payload?: any, options?: Object)`
+- `commit(mutation: Object, options?: Object)`
 
-  Commit a mutation. `options` can have `root: true` that allows to commit root mutations in [namespaced modules](../guide/modules.md#namespacing). [Details](../guide/mutations.md)
+Commit a mutation. `options` can have `root: true` that allows to commit root mutations in [namespaced modules](../guide/modules.md#namespacing). [Details](../guide/mutations.md)
 
 ### dispatch
 
--  `dispatch(type: string, payload?: any, options?: Object): Promise<any>`
--  `dispatch(action: Object, options?: Object): Promise<any>`
+- `dispatch(type: string, payload?: any, options?: Object): Promise<any>`
+- `dispatch(action: Object, options?: Object): Promise<any>`
 
-  Dispatch an action. `options` can have `root: true` that allows to dispatch root actions in [namespaced modules](../guide/modules.md#namespacing). Returns a Promise that resolves all triggered action handlers. [Details](../guide/actions.md)
+Dispatch an action. `options` can have `root: true` that allows to dispatch root actions in [namespaced modules](../guide/modules.md#namespacing). Returns a Promise that resolves all triggered action handlers. [Details](../guide/actions.md)
 
 ### replaceState
 
--  `replaceState(state: Object)`
+- `replaceState(state: Object)`
 
-  Replace the store's root state. Use this only for state hydration / time-travel purposes.
+Replace the store's root state. Use this only for state hydration / time-travel purposes.
 
 ### watch
 
--  `watch(fn: Function, callback: Function, options?: Object): Function`
+- `watch(fn: Function, callback: Function, options?: Object): Function`
 
-  Reactively watch `fn`'s return value, and call the callback when the value changes. `fn` receives the store's state as the first argument, and getters as the second argument. Accepts an optional options object that takes the same options as [Vue's `vm.$watch` method](https://vuejs.org/v2/api/#vm-watch).
+Reactively watch `fn`'s return value, and call the callback when the value changes. `fn` receives the store's state as the first argument, and getters as the second argument. Accepts an optional options object that takes the same options as [Vue's `vm.$watch` method](https://vuejs.org/v2/api/#vm-watch).
 
-  To stop watching, call the returned unwatch function.
+To stop watching, call the returned unwatch function.
 
 ### subscribe
 
--  `subscribe(handler: Function, options?: Object): Function`
+- `subscribe(handler: Function, options?: Object): Function`
 
-  Subscribe to store mutations. The `handler` is called after every mutation and receives the mutation descriptor and post-mutation state as arguments.
+Subscribe to store mutations. The `handler` is called after every mutation and receives the mutation descriptor and post-mutation state as arguments.
 
-  ```js
-  const unsubscribe = store.subscribe((mutation, state) => {
-    console.log(mutation.type)
-    console.log(mutation.payload)
-  })
+```js
+const unsubscribe = store.subscribe((mutation, state) => {
+  console.log(mutation.type);
+  console.log(mutation.payload);
+});
 
-  // you may call unsubscribe to stop the subscription
-  unsubscribe()
-  ```
+// you may call unsubscribe to stop the subscription
+unsubscribe();
+```
 
-  By default, new handler is added to the end of the chain, so it will be executed after other handlers that were added before. This can be overridden by adding `prepend: true` to `options`, which will add the handler to the beginning of the chain.
+By default, new handler is added to the end of the chain, so it will be executed after other handlers that were added before. This can be overridden by adding `prepend: true` to `options`, which will add the handler to the beginning of the chain.
 
-  ```js
-  store.subscribe(handler, { prepend: true })
-  ```
+```js
+store.subscribe(handler, { prepend: true });
+```
 
-  The `subscribe` method will return an `unsubscribe` function, which should be called when the subscription is no longer needed. For example, you might subscribe to a Vuex Module and unsubscribe when you unregister the module. Or you might call `subscribe` from inside a Vue Component and then destroy the component later. In these cases, you should remember to unsubscribe the subscription manually.
+The `subscribe` method will return an `unsubscribe` function, which should be called when the subscription is no longer needed. For example, you might subscribe to a Vuex Module and unsubscribe when you unregister the module. Or you might call `subscribe` from inside a Vue Component and then destroy the component later. In these cases, you should remember to unsubscribe the subscription manually.
 
-  Most commonly used in plugins. [Details](../guide/plugins.md)
+Most commonly used in plugins. [Details](../guide/plugins.md)
 
 ### subscribeAction
 
--  `subscribeAction(handler: Function, options?: Object): Function`
+- `subscribeAction(handler: Function, options?: Object): Function`
 
-  Subscribe to store actions. The `handler` is called for every dispatched action and receives the action descriptor and current store state as arguments.
-  The `subscribe` method will return an `unsubscribe` function, which should be called when the subscription is no longer needed. For example, when unregistering a Vuex module or before destroying a Vue component.
+Subscribe to store actions. The `handler` is called for every dispatched action and receives the action descriptor and current store state as arguments.
+The `subscribe` method will return an `unsubscribe` function, which should be called when the subscription is no longer needed. For example, when unregistering a Vuex module or before destroying a Vue component.
 
-  ```js
-  const unsubscribe = store.subscribeAction((action, state) => {
-    console.log(action.type)
-    console.log(action.payload)
-  })
+```js
+const unsubscribe = store.subscribeAction((action, state) => {
+  console.log(action.type);
+  console.log(action.payload);
+});
 
-  // you may call unsubscribe to stop the subscription
-  unsubscribe()
-  ```
+// you may call unsubscribe to stop the subscription
+unsubscribe();
+```
 
-  By default, new handler is added to the end of the chain, so it will be executed after other handlers that were added before. This can be overridden by adding `prepend: true` to `options`, which will add the handler to the beginning of the chain.
+By default, new handler is added to the end of the chain, so it will be executed after other handlers that were added before. This can be overridden by adding `prepend: true` to `options`, which will add the handler to the beginning of the chain.
 
-  ```js
-  store.subscribeAction(handler, { prepend: true })
-  ```
+```js
+store.subscribeAction(handler, { prepend: true });
+```
 
-  The `subscribeAction` method will return an `unsubscribe` function, which should be called when the subscription is no longer needed. For example, you might subscribe to a Vuex Module and unsubscribe when you unregister the module. Or you might call `subscribeAction` from inside a Vue Component and then destroy the component later. In these cases, you should remember to unsubscribe the subscription manually.
+The `subscribeAction` method will return an `unsubscribe` function, which should be called when the subscription is no longer needed. For example, you might subscribe to a Vuex Module and unsubscribe when you unregister the module. Or you might call `subscribeAction` from inside a Vue Component and then destroy the component later. In these cases, you should remember to unsubscribe the subscription manually.
 
-  `subscribeAction` can also specify whether the subscribe handler should be called *before* or *after* an action dispatch (the default behavior is *before*):
+`subscribeAction` can also specify whether the subscribe handler should be called _before_ or _after_ an action dispatch (the default behavior is _before_):
 
-  ```js
-  store.subscribeAction({
-    before: (action, state) => {
-      console.log(`before action ${action.type}`)
-    },
-    after: (action, state) => {
-      console.log(`after action ${action.type}`)
-    }
-  })
-  ```
+```js
+store.subscribeAction({
+  before: (action, state) => {
+    console.log(`before action ${action.type}`);
+  },
+  after: (action, state) => {
+    console.log(`after action ${action.type}`);
+  },
+});
+```
 
-  `subscribeAction` can also specify an `error` handler to catch an error thrown when an action is dispatched. The function will receive an `error` object as the third argument.
+`subscribeAction` can also specify an `error` handler to catch an error thrown when an action is dispatched. The function will receive an `error` object as the third argument.
 
-  ```js
-  store.subscribeAction({
-    error: (action, state, error) => {
-      console.log(`error action ${action.type}`)
-      console.error(error)
-    }
-  })
-  ```
+```js
+store.subscribeAction({
+  error: (action, state, error) => {
+    console.log(`error action ${action.type}`);
+    console.error(error);
+  },
+});
+```
 
-  The `subscribeAction` method is most commonly used in plugins. [Details](../guide/plugins.md)
+The `subscribeAction` method is most commonly used in plugins. [Details](../guide/plugins.md)
 
 ### registerModule
 
--  `registerModule(path: string | Array<string>, module: Module, options?: Object)`
+- `registerModule(path: string | Array<string>, module: Module, options?: Object)`
 
-  Register a dynamic module. [Details](../guide/modules.md#dynamic-module-registration)
+Register a dynamic module. [Details](../guide/modules.md#dynamic-module-registration)
 
-  `options` can have `preserveState: true` that allows to preserve the previous state. Useful with Server Side Rendering.
+`options` can have `preserveState: true` that allows to preserve the previous state. Useful with Server Side Rendering.
 
 ### unregisterModule
 
--  `unregisterModule(path: string | Array<string>)`
+- `unregisterModule(path: string | Array<string>)`
 
-  Unregister a dynamic module. [Details](../guide/modules.md#dynamic-module-registration)
+Unregister a dynamic module. [Details](../guide/modules.md#dynamic-module-registration)
 
 ### hasModule
 
@@ -277,55 +277,93 @@ sidebar: auto
 
 ### hotUpdate
 
--  `hotUpdate(newOptions: Object)`
+- `hotUpdate(newOptions: Object)`
 
-  Hot swap new actions and mutations. [Details](../guide/hot-reload.md)
+Hot swap new actions and mutations. [Details](../guide/hot-reload.md)
 
 ## Component Binding Helpers
 
 ### mapState
 
--  `mapState(namespace?: string, map: Array<string> | Object<string | function>): Object`
+- `mapState(namespace?: string, map: Array<string> | Object<string | function>): Object`
 
-  Create component computed options that return the sub tree of the Vuex store. [Details](../guide/state.md#the-mapstate-helper)
+Create component computed options that return the sub tree of the Vuex store. [Details](../guide/state.md#the-mapstate-helper)
 
-  The first argument can optionally be a namespace string. [Details](../guide/modules.md#binding-helpers-with-namespace)
+The first argument can optionally be a namespace string. [Details](../guide/modules.md#binding-helpers-with-namespace)
 
-  The second object argument's members can be a function. `function(state: any)`
+The second object argument's members can be a function. `function(state: any)`
 
 ### mapGetters
 
--  `mapGetters(namespace?: string, map: Array<string> | Object<string>): Object`
+- `mapGetters(namespace?: string, map: Array<string> | Object<string>): Object`
 
-  Create component computed options that return the evaluated value of a getter. [Details](../guide/getters.md#the-mapgetters-helper)
+Create component computed options that return the evaluated value of a getter. [Details](../guide/getters.md#the-mapgetters-helper)
 
-  The first argument can optionally be a namespace string. [Details](../guide/modules.md#binding-helpers-with-namespace)
+The first argument can optionally be a namespace string. [Details](../guide/modules.md#binding-helpers-with-namespace)
 
 ### mapActions
 
--  `mapActions(namespace?: string, map: Array<string> | Object<string | function>): Object`
+- `mapActions(namespace?: string, map: Array<string> | Object<string | function>): Object`
 
-  Create component methods options that dispatch an action. [Details](../guide/actions.md#dispatching-actions-in-components)
+Create component methods options that dispatch an action. [Details](../guide/actions.md#dispatching-actions-in-components)
 
-  The first argument can optionally be a namespace string. [Details](../guide/modules.md#binding-helpers-with-namespace)
+The first argument can optionally be a namespace string. [Details](../guide/modules.md#binding-helpers-with-namespace)
 
-  The second object argument's members can be a function. `function(dispatch: function, ...args: any[])`
+The second object argument's members can be a function. `function(dispatch: function, ...args: any[])`
 
 ### mapMutations
 
--  `mapMutations(namespace?: string, map: Array<string> | Object<string | function>): Object`
+- `mapMutations(namespace?: string, map: Array<string> | Object<string | function>): Object`
 
-  Create component methods options that commit a mutation. [Details](../guide/mutations.md#committing-mutations-in-components)
+Create component methods options that commit a mutation. [Details](../guide/mutations.md#committing-mutations-in-components)
 
-  The first argument can optionally be a namespace string. [Details](../guide/modules.md#binding-helpers-with-namespace)
+The first argument can optionally be a namespace string. [Details](../guide/modules.md#binding-helpers-with-namespace)
 
-  The second object argument's members can be a function. `function(commit: function, ...args: any[])`
+The second object argument's members can be a function. `function(commit: function, ...args: any[])`
 
 ### createNamespacedHelpers
 
--  `createNamespacedHelpers(namespace: string): Object`
+- `createNamespacedHelpers(namespace: string): Object`
 
-  Create namespaced component binding helpers. The returned object contains `mapState`, `mapGetters`, `mapActions` and `mapMutations` that are bound with the given namespace. [Details](../guide/modules.md#binding-helpers-with-namespace)
+Create namespaced component binding helpers. The returned object contains `mapState`, `mapGetters`, `mapActions` and `mapMutations` that are bound with the given namespace. [Details](../guide/modules.md#binding-helpers-with-namespace)
+
+### useState
+
+- `useState(namespace?: string, map: Array<string> | Object<string | function>): Object`
+
+Create component computed options that return the sub tree of the Vuex store. [Details](../guide/state.md#-The-`useState`-Helper)
+
+The first argument can optionally be a namespace string. [Details](../guide/modules.md#binding-helpers-with-namespace)
+
+The second object argument's members can be a function. `function(state: any)`
+
+### useGetters
+
+- `useGetters(namespace?: string, map: Array<string> | Object<string>): Object`
+
+Create component computed options that return the evaluated value of a getter. [Details](../guide/getters.md#-The-`useGetters`-Helperr)
+
+The first argument can optionally be a namespace string. [Details](../guide/modules.md#binding-helpers-with-namespace)
+
+### useActions
+
+- `useActions(namespace?: string, map: Array<string> | Object<string | function>): Object`
+
+Create component methods options that dispatch an action. [Details](../guide/actions.md#-The-`useActions`-Helper)
+
+The first argument can optionally be a namespace string. [Details](../guide/modules.md#binding-helpers-with-namespace)
+
+The second object argument's members can be a function. `function(dispatch: function, ...args: any[])`
+
+### useMutations
+
+- `useMutations(namespace?: string, map: Array<string> | Object<string | function>): Object`
+
+Create component methods options that commit a mutation. [Details](../guide/mutations.md#-The-`useMutations`-Helper)
+
+The first argument can optionally be a namespace string. [Details](../guide/modules.md#binding-helpers-with-namespace)
+
+The second object argument's members can be a function. `function(commit: function, ...args: any[])`
 
 ## Composable Functions
 
@@ -336,13 +374,13 @@ sidebar: auto
   Fetches the injected store when called inside the `setup` hook. When using the Composition API, you can retrieve the store by calling this method.
 
   ```js
-  import { useStore } from 'vuex'
+  import { useStore } from "vuex";
 
   export default {
-    setup () {
-      const store = useStore()
-    }
-  }
+    setup() {
+      const store = useStore();
+    },
+  };
   ```
 
   TypeScript users can use an injection key to retrieve a typed store. In order for this to work, you must define the injection key and pass it along with the store when installing the store instance to the Vue app.
@@ -351,20 +389,20 @@ sidebar: auto
 
   ```ts
   // store.ts
-  import { InjectionKey } from 'vue'
-  import { createStore, Store } from 'vuex'
+  import { InjectionKey } from "vue";
+  import { createStore, Store } from "vuex";
 
   export interface State {
-    count: number
+    count: number;
   }
 
-  export const key: InjectionKey<Store<State>> = Symbol()
+  export const key: InjectionKey<Store<State>> = Symbol();
 
   export const store = createStore<State>({
     state: {
-      count: 0
-    }
-  })
+      count: 0,
+    },
+  });
   ```
 
   Then, pass the defined key as the second argument for the `app.use` method.
@@ -385,14 +423,14 @@ sidebar: auto
 
   ```ts
   // in a vue component
-  import { useStore } from 'vuex'
-  import { key } from './store'
+  import { useStore } from "vuex";
+  import { key } from "./store";
 
   export default {
-    setup () {
-      const store = useStore(key)
+    setup() {
+      const store = useStore(key);
 
-      store.state.count // typed as number
-    }
-  }
+      store.state.count; // typed as number
+    },
+  };
   ```

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -13,9 +13,9 @@ sidebar: auto
   Creates a new store.
 
   ```js
-  import { createStore } from "vuex";
+  import { createStore } from 'vuex'
 
-  const store = createStore({ ...options });
+  const store = createStore({ ...options })
   ```
 
 ## Store Constructor Options
@@ -49,7 +49,7 @@ sidebar: auto
       commit, // same as `store.commit`
       dispatch, // same as `store.dispatch`
       getters, // same as `store.getters`, or local getters if in modules
-      rootGetters; // same as `store.getters`, only in modules
+      rootGetters // same as `store.getters`, only in modules
   }
   ```
 
@@ -130,7 +130,7 @@ sidebar: auto
 
   ```js
   {
-    devtools: false;
+    devtools: false
   }
   ```
 
@@ -186,18 +186,18 @@ Subscribe to store mutations. The `handler` is called after every mutation and r
 
 ```js
 const unsubscribe = store.subscribe((mutation, state) => {
-  console.log(mutation.type);
-  console.log(mutation.payload);
-});
+  console.log(mutation.type)
+  console.log(mutation.payload)
+})
 
 // you may call unsubscribe to stop the subscription
-unsubscribe();
+unsubscribe()
 ```
 
 By default, new handler is added to the end of the chain, so it will be executed after other handlers that were added before. This can be overridden by adding `prepend: true` to `options`, which will add the handler to the beginning of the chain.
 
 ```js
-store.subscribe(handler, { prepend: true });
+store.subscribe(handler, { prepend: true })
 ```
 
 The `subscribe` method will return an `unsubscribe` function, which should be called when the subscription is no longer needed. For example, you might subscribe to a Vuex Module and unsubscribe when you unregister the module. Or you might call `subscribe` from inside a Vue Component and then destroy the component later. In these cases, you should remember to unsubscribe the subscription manually.
@@ -213,18 +213,18 @@ The `subscribe` method will return an `unsubscribe` function, which should be ca
 
 ```js
 const unsubscribe = store.subscribeAction((action, state) => {
-  console.log(action.type);
-  console.log(action.payload);
-});
+  console.log(action.type)
+  console.log(action.payload)
+})
 
 // you may call unsubscribe to stop the subscription
-unsubscribe();
+unsubscribe()
 ```
 
 By default, new handler is added to the end of the chain, so it will be executed after other handlers that were added before. This can be overridden by adding `prepend: true` to `options`, which will add the handler to the beginning of the chain.
 
 ```js
-store.subscribeAction(handler, { prepend: true });
+store.subscribeAction(handler, { prepend: true })
 ```
 
 The `subscribeAction` method will return an `unsubscribe` function, which should be called when the subscription is no longer needed. For example, you might subscribe to a Vuex Module and unsubscribe when you unregister the module. Or you might call `subscribeAction` from inside a Vue Component and then destroy the component later. In these cases, you should remember to unsubscribe the subscription manually.
@@ -234,12 +234,12 @@ The `subscribeAction` method will return an `unsubscribe` function, which should
 ```js
 store.subscribeAction({
   before: (action, state) => {
-    console.log(`before action ${action.type}`);
+    console.log(`before action ${action.type}`)
   },
   after: (action, state) => {
-    console.log(`after action ${action.type}`);
-  },
-});
+    console.log(`after action ${action.type}`)
+  }
+})
 ```
 
 `subscribeAction` can also specify an `error` handler to catch an error thrown when an action is dispatched. The function will receive an `error` object as the third argument.
@@ -247,10 +247,10 @@ store.subscribeAction({
 ```js
 store.subscribeAction({
   error: (action, state, error) => {
-    console.log(`error action ${action.type}`);
-    console.error(error);
-  },
-});
+    console.log(`error action ${action.type}`)
+    console.error(error)
+  }
+})
 ```
 
 The `subscribeAction` method is most commonly used in plugins. [Details](../guide/plugins.md)
@@ -374,13 +374,13 @@ The second object argument's members can be a function. `function(commit: functi
   Fetches the injected store when called inside the `setup` hook. When using the Composition API, you can retrieve the store by calling this method.
 
   ```js
-  import { useStore } from "vuex";
+  import { useStore } from 'vuex'
 
   export default {
     setup() {
-      const store = useStore();
-    },
-  };
+      const store = useStore()
+    }
+  }
   ```
 
   TypeScript users can use an injection key to retrieve a typed store. In order for this to work, you must define the injection key and pass it along with the store when installing the store instance to the Vue app.
@@ -389,20 +389,20 @@ The second object argument's members can be a function. `function(commit: functi
 
   ```ts
   // store.ts
-  import { InjectionKey } from "vue";
-  import { createStore, Store } from "vuex";
+  import { InjectionKey } from 'vue'
+  import { createStore, Store } from 'vuex'
 
   export interface State {
-    count: number;
+    count: number
   }
 
-  export const key: InjectionKey<Store<State>> = Symbol();
+  export const key: InjectionKey<Store<State>> = Symbol()
 
   export const store = createStore<State>({
     state: {
-      count: 0,
-    },
-  });
+      count: 0
+    }
+  })
   ```
 
   Then, pass the defined key as the second argument for the `app.use` method.
@@ -423,14 +423,14 @@ The second object argument's members can be a function. `function(commit: functi
 
   ```ts
   // in a vue component
-  import { useStore } from "vuex";
-  import { key } from "./store";
+  import { useStore } from 'vuex'
+  import { key } from './store'
 
   export default {
     setup() {
-      const store = useStore(key);
+      const store = useStore(key)
 
-      store.state.count; // typed as number
-    },
-  };
+      store.state.count // typed as number
+    }
+  }
   ```

--- a/docs/guide/actions.md
+++ b/docs/guide/actions.md
@@ -12,19 +12,19 @@ Let's register a simple action:
 ```js
 const store = createStore({
   state: {
-    count: 0,
+    count: 0
   },
   mutations: {
     increment(state) {
-      state.count++;
-    },
+      state.count++
+    }
   },
   actions: {
     increment(context) {
-      context.commit("increment");
-    },
-  },
-});
+      context.commit('increment')
+    }
+  }
+})
 ```
 
 Action handlers receive a context object which exposes the same set of methods/properties on the store instance, so you can call `context.commit` to commit a mutation, or access the state and getters via `context.state` and `context.getters`. We can even call other actions with `context.dispatch`. We will see why this context object is not the store instance itself when we introduce [Modules](modules.md) later.
@@ -44,7 +44,7 @@ actions: {
 Actions are triggered with the `store.dispatch` method:
 
 ```js
-store.dispatch("increment");
+store.dispatch('increment')
 ```
 
 This may look silly at first sight: if we want to increment the count, why don't we just call `store.commit('increment')` directly? Remember that **mutations have to be synchronous**. Actions don't. We can perform **asynchronous** operations inside an action:
@@ -63,15 +63,15 @@ Actions support the same payload format and object-style dispatch:
 
 ```js
 // dispatch with a payload
-store.dispatch("incrementAsync", {
-  amount: 10,
-});
+store.dispatch('incrementAsync', {
+  amount: 10
+})
 
 // dispatch with an object
 store.dispatch({
-  type: "incrementAsync",
-  amount: 10,
-});
+  type: 'incrementAsync',
+  amount: 10
+})
 ```
 
 A more practical example of real-world actions would be an action to checkout a shopping cart, which involves **calling an async API** and **committing multiple mutations**:
@@ -103,22 +103,22 @@ Note we are performing a flow of asynchronous operations, and recording the side
 You can dispatch actions in components with `this.$store.dispatch('xxx')`, or use the `mapActions` helper which maps component methods to `store.dispatch` calls (requires root `store` injection):
 
 ```js
-import { mapActions } from "vuex";
+import { mapActions } from 'vuex'
 
 export default {
   // ...
   methods: {
     ...mapActions([
-      "increment", // map `this.increment()` to `this.$store.dispatch('increment')`
+      'increment', // map `this.increment()` to `this.$store.dispatch('increment')`
 
       // `mapActions` also supports payloads:
-      "incrementBy", // map `this.incrementBy(amount)` to `this.$store.dispatch('incrementBy', amount)`
+      'incrementBy' // map `this.incrementBy(amount)` to `this.$store.dispatch('incrementBy', amount)`
     ]),
     ...mapActions({
-      add: "increment", // map `this.add()` to `this.$store.dispatch('increment')`
-    }),
-  },
-};
+      add: 'increment' // map `this.add()` to `this.$store.dispatch('increment')`
+    })
+  }
+}
 ```
 
 ## Composing Actions
@@ -143,9 +143,9 @@ actions: {
 Now you can do:
 
 ```js
-store.dispatch("actionA").then(() => {
+store.dispatch('actionA').then(() => {
   // ...
-});
+})
 ```
 
 And also in another action:
@@ -200,15 +200,15 @@ export default {
 or object destructuring
 
 ```js
-import { useActions } from "vuex";
+import { useActions } from 'vuex'
 
 export default {
   setup() {
     return {
-      ...useActions(["increment"]),
-    };
-  },
-};
+      ...useActions(['increment'])
+    }
+  }
+}
 ```
 
 You can learn more in the [Composition API](./composition-api#New-helper-methods-for-Composition-API) section.

--- a/docs/guide/actions.md
+++ b/docs/guide/actions.md
@@ -9,29 +9,29 @@ Actions are similar to mutations, the differences being that:
 
 Let's register a simple action:
 
-``` js
+```js
 const store = createStore({
   state: {
-    count: 0
+    count: 0,
   },
   mutations: {
-    increment (state) {
-      state.count++
-    }
+    increment(state) {
+      state.count++;
+    },
   },
   actions: {
-    increment (context) {
-      context.commit('increment')
-    }
-  }
-})
+    increment(context) {
+      context.commit("increment");
+    },
+  },
+});
 ```
 
 Action handlers receive a context object which exposes the same set of methods/properties on the store instance, so you can call `context.commit` to commit a mutation, or access the state and getters via `context.state` and `context.getters`. We can even call other actions with `context.dispatch`. We will see why this context object is not the store instance itself when we introduce [Modules](modules.md) later.
 
 In practice, we often use ES2015 [argument destructuring](https://github.com/lukehoban/es6features#destructuring) to simplify the code a bit (especially when we need to call `commit` multiple times):
 
-``` js
+```js
 actions: {
   increment ({ commit }) {
     commit('increment')
@@ -43,13 +43,13 @@ actions: {
 
 Actions are triggered with the `store.dispatch` method:
 
-``` js
-store.dispatch('increment')
+```js
+store.dispatch("increment");
 ```
 
 This may look silly at first sight: if we want to increment the count, why don't we just call `store.commit('increment')` directly? Remember that **mutations have to be synchronous**. Actions don't. We can perform **asynchronous** operations inside an action:
 
-``` js
+```js
 actions: {
   incrementAsync ({ commit }) {
     setTimeout(() => {
@@ -61,22 +61,22 @@ actions: {
 
 Actions support the same payload format and object-style dispatch:
 
-``` js
+```js
 // dispatch with a payload
-store.dispatch('incrementAsync', {
-  amount: 10
-})
+store.dispatch("incrementAsync", {
+  amount: 10,
+});
 
 // dispatch with an object
 store.dispatch({
-  type: 'incrementAsync',
-  amount: 10
-})
+  type: "incrementAsync",
+  amount: 10,
+});
 ```
 
 A more practical example of real-world actions would be an action to checkout a shopping cart, which involves **calling an async API** and **committing multiple mutations**:
 
-``` js
+```js
 actions: {
   checkout ({ commit, state }, products) {
     // save the items currently in the cart
@@ -102,23 +102,23 @@ Note we are performing a flow of asynchronous operations, and recording the side
 
 You can dispatch actions in components with `this.$store.dispatch('xxx')`, or use the `mapActions` helper which maps component methods to `store.dispatch` calls (requires root `store` injection):
 
-``` js
-import { mapActions } from 'vuex'
+```js
+import { mapActions } from "vuex";
 
 export default {
   // ...
   methods: {
     ...mapActions([
-      'increment', // map `this.increment()` to `this.$store.dispatch('increment')`
+      "increment", // map `this.increment()` to `this.$store.dispatch('increment')`
 
       // `mapActions` also supports payloads:
-      'incrementBy' // map `this.incrementBy(amount)` to `this.$store.dispatch('incrementBy', amount)`
+      "incrementBy", // map `this.incrementBy(amount)` to `this.$store.dispatch('incrementBy', amount)`
     ]),
     ...mapActions({
-      add: 'increment' // map `this.add()` to `this.$store.dispatch('increment')`
-    })
-  }
-}
+      add: "increment", // map `this.add()` to `this.$store.dispatch('increment')`
+    }),
+  },
+};
 ```
 
 ## Composing Actions
@@ -127,7 +127,7 @@ Actions are often asynchronous, so how do we know when an action is done? And mo
 
 The first thing to know is that `store.dispatch` can handle Promise returned by the triggered action handler and it also returns Promise:
 
-``` js
+```js
 actions: {
   actionA ({ commit }) {
     return new Promise((resolve, reject) => {
@@ -142,15 +142,15 @@ actions: {
 
 Now you can do:
 
-``` js
-store.dispatch('actionA').then(() => {
+```js
+store.dispatch("actionA").then(() => {
   // ...
-})
+});
 ```
 
 And also in another action:
 
-``` js
+```js
 actions: {
   // ...
   actionB ({ dispatch, commit }) {
@@ -163,7 +163,7 @@ actions: {
 
 Finally, if we make use of [async / await](https://tc39.github.io/ecmascript-asyncawait/), we can compose our actions like this:
 
-``` js
+```js
 // assuming `getData()` and `getOtherData()` return Promises
 
 actions: {
@@ -178,3 +178,37 @@ actions: {
 ```
 
 > It's possible for a `store.dispatch` to trigger multiple action handlers in different modules. In such a case the returned value will be a Promise that resolves when all triggered handlers have been resolved.
+
+## The `useActions` Helper
+
+This works the same way as the `mapActions` helper but is compatible with the composition API `setup()` function.
+
+```js
+import { useActions } from "vuex";
+
+export default {
+  setup() {
+
+    const { increment } = useActions(["increment"])
+
+    return {
+      increment
+    };
+  },
+```
+
+or object destructuring
+
+```js
+import { useActions } from "vuex";
+
+export default {
+  setup() {
+    return {
+      ...useActions(["increment"]),
+    };
+  },
+};
+```
+
+You can learn more in the [Composition API](./composition-api#New-helper-methods-for-Composition-API) section.

--- a/docs/guide/composition-api.md
+++ b/docs/guide/composition-api.md
@@ -3,13 +3,13 @@
 To access the store within the `setup` hook, you can call the `useStore` function. This is the equivalent of retrieving `this.$store` within a component using the Option API.
 
 ```js
-import { useStore } from "vuex";
+import { useStore } from 'vuex'
 
 export default {
   setup() {
-    const store = useStore();
-  },
-};
+    const store = useStore()
+  }
+}
 ```
 
 ## Accessing State and Getters
@@ -17,22 +17,22 @@ export default {
 In order to access state and getters, you will want to create `computed` references to retain reactivity. This is the equivalent of creating computed properties using the Option API.
 
 ```js
-import { computed } from "vue";
-import { useStore } from "vuex";
+import { computed } from 'vue'
+import { useStore } from 'vuex'
 
 export default {
   setup() {
-    const store = useStore();
+    const store = useStore()
 
     return {
       // access a state in computed function
       count: computed(() => store.state.count),
 
       // access a getter in computed function
-      double: computed(() => store.getters.double),
-    };
-  },
-};
+      double: computed(() => store.getters.double)
+    }
+  }
+}
 ```
 
 ## Accessing Mutations and Actions
@@ -40,21 +40,21 @@ export default {
 When accessing mutations and actions, you can simply provide the `commit` and `dispatch` function inside the `setup` hook.
 
 ```js
-import { useStore } from "vuex";
+import { useStore } from 'vuex'
 
 export default {
   setup() {
-    const store = useStore();
+    const store = useStore()
 
     return {
       // access a mutation
-      increment: () => store.commit("increment"),
+      increment: () => store.commit('increment'),
 
       // access an action
-      asyncIncrement: () => store.dispatch("asyncIncrement"),
-    };
-  },
-};
+      asyncIncrement: () => store.dispatch('asyncIncrement')
+    }
+  }
+}
 ```
 
 ## New helper methods for Composition API
@@ -62,27 +62,27 @@ export default {
 The `mapXXX` methods from vuex 3 do not work with the new `setup()` function in the composition API therefore the new `useXXX` methods allow for all the old funcionallity of the the mapping functions but with the `setup()` function.
 
 ```js
-import { useState } from "vuex";
+import { useState } from 'vuex'
 export default {
   setup() {
     return {
-      ...useState(["someState", "someOtherState"]),
-    };
-  },
-};
+      ...useState(['someState', 'someOtherState'])
+    }
+  }
+}
 ```
 
 Giving a property an alias:
 
 ```js
-import { useState } from "vuex";
+import { useState } from 'vuex'
 export default {
   setup() {
     return {
-      ...useState({ countAlias: "count" }),
-    };
-  },
-};
+      ...useState({ countAlias: 'count' })
+    }
+  }
+}
 ```
 
 ## Examples

--- a/docs/guide/composition-api.md
+++ b/docs/guide/composition-api.md
@@ -3,13 +3,13 @@
 To access the store within the `setup` hook, you can call the `useStore` function. This is the equivalent of retrieving `this.$store` within a component using the Option API.
 
 ```js
-import { useStore } from 'vuex'
+import { useStore } from "vuex";
 
 export default {
-  setup () {
-    const store = useStore()
-  }
-}
+  setup() {
+    const store = useStore();
+  },
+};
 ```
 
 ## Accessing State and Getters
@@ -17,22 +17,22 @@ export default {
 In order to access state and getters, you will want to create `computed` references to retain reactivity. This is the equivalent of creating computed properties using the Option API.
 
 ```js
-import { computed } from 'vue'
-import { useStore } from 'vuex'
+import { computed } from "vue";
+import { useStore } from "vuex";
 
 export default {
-  setup () {
-    const store = useStore()
+  setup() {
+    const store = useStore();
 
     return {
       // access a state in computed function
       count: computed(() => store.state.count),
 
       // access a getter in computed function
-      double: computed(() => store.getters.double)
-    }
-  }
-}
+      double: computed(() => store.getters.double),
+    };
+  },
+};
 ```
 
 ## Accessing Mutations and Actions
@@ -40,21 +40,49 @@ export default {
 When accessing mutations and actions, you can simply provide the `commit` and `dispatch` function inside the `setup` hook.
 
 ```js
-import { useStore } from 'vuex'
+import { useStore } from "vuex";
 
 export default {
-  setup () {
-    const store = useStore()
+  setup() {
+    const store = useStore();
 
     return {
       // access a mutation
-      increment: () => store.commit('increment'),
+      increment: () => store.commit("increment"),
 
       // access an action
-      asyncIncrement: () => store.dispatch('asyncIncrement')
-    }
-  }
-}
+      asyncIncrement: () => store.dispatch("asyncIncrement"),
+    };
+  },
+};
+```
+
+## New helper methods for Composition API
+
+The `mapXXX` methods from vuex 3 do not work with the new `setup()` function in the composition API therefore the new `useXXX` methods allow for all the old funcionallity of the the mapping functions but with the `setup()` function.
+
+```js
+import { useState } from "vuex";
+export default {
+  setup() {
+    return {
+      ...useState(["someState", "someOtherState"]),
+    };
+  },
+};
+```
+
+Giving a property an alias:
+
+```js
+import { useState } from "vuex";
+export default {
+  setup() {
+    return {
+      ...useState({ countAlias: "count" }),
+    };
+  },
+};
 ```
 
 ## Examples

--- a/docs/guide/getters.md
+++ b/docs/guide/getters.md
@@ -4,7 +4,7 @@
 
 Sometimes we may need to compute derived state based on store state, for example filtering through a list of items and counting them:
 
-``` js
+```js
 computed: {
   doneTodosCount () {
     return this.$store.state.todos.filter(todo => todo.done).length
@@ -22,33 +22,33 @@ As of Vue 3.0, the getter's result is **not cached** as the computed property do
 
 Getters will receive the state as their 1st argument:
 
-``` js
+```js
 const store = createStore({
   state: {
     todos: [
-      { id: 1, text: '...', done: true },
-      { id: 2, text: '...', done: false }
-    ]
+      { id: 1, text: "...", done: true },
+      { id: 2, text: "...", done: false },
+    ],
   },
   getters: {
-    doneTodos (state) {
-      return state.todos.filter(todo => todo.done)
-    }
-  }
-})
+    doneTodos(state) {
+      return state.todos.filter((todo) => todo.done);
+    },
+  },
+});
 ```
 
 ## Property-Style Access
 
 The getters will be exposed on the `store.getters` object, and you access values as properties:
 
-``` js
-store.getters.doneTodos // -> [{ id: 1, text: '...', done: true }]
+```js
+store.getters.doneTodos; // -> [{ id: 1, text: '...', done: true }]
 ```
 
 Getters will also receive other getters as the 2nd argument:
 
-``` js
+```js
 getters: {
   // ...
   doneTodosCount (state, getters) {
@@ -57,13 +57,13 @@ getters: {
 }
 ```
 
-``` js
-store.getters.doneTodosCount // -> 1
+```js
+store.getters.doneTodosCount; // -> 1
 ```
 
 We can now easily make use of it inside any component:
 
-``` js
+```js
 computed: {
   doneTodosCount () {
     return this.$store.getters.doneTodosCount
@@ -81,13 +81,13 @@ You can also pass arguments to getters by returning a function. This is particul
 getters: {
   // ...
   getTodoById: (state) => (id) => {
-    return state.todos.find(todo => todo.id === id)
-  }
+    return state.todos.find((todo) => todo.id === id);
+  };
 }
 ```
 
-``` js
-store.getters.getTodoById(2) // -> { id: 2, text: '...', done: false }
+```js
+store.getters.getTodoById(2); // -> { id: 2, text: '...', done: false }
 ```
 
 Note that getters accessed via methods will run each time you call them, and the result is not cached.
@@ -96,27 +96,62 @@ Note that getters accessed via methods will run each time you call them, and the
 
 The `mapGetters` helper simply maps store getters to local computed properties:
 
-``` js
-import { mapGetters } from 'vuex'
+```js
+import { mapGetters } from "vuex";
 
 export default {
   // ...
   computed: {
     // mix the getters into computed with object spread operator
     ...mapGetters([
-      'doneTodosCount',
-      'anotherGetter',
+      "doneTodosCount",
+      "anotherGetter",
       // ...
-    ])
-  }
-}
+    ]),
+  },
+};
 ```
 
 If you want to map a getter to a different name, use an object:
 
-``` js
+```js
 ...mapGetters({
   // map `this.doneCount` to `this.$store.getters.doneTodosCount`
   doneCount: 'doneTodosCount'
 })
 ```
+
+## The `useGetters` Helper
+
+This works the same way as the `mapGetters` helper but is compatible with the composition API `setup()` function.
+
+```js
+import { useGetters } from "vuex";
+
+export default {
+  setup() {
+
+    const { doneTodosCount, anotherGetter } = useGetters(["doneTodosCount", "anotherGetter"])
+
+    return {
+      doneTodosCount,
+      anotherGetter
+    };
+  },
+```
+
+or object destructuring
+
+```js
+import { useGetters } from "vuex";
+
+export default {
+  setup() {
+    return {
+      ...useGetters(["doneTodosCount", "anotherGetter"]),
+    };
+  },
+};
+```
+
+You can learn more in the [Composition API](./composition-api#New-helper-methods-for-Composition-API) section.

--- a/docs/guide/getters.md
+++ b/docs/guide/getters.md
@@ -26,16 +26,16 @@ Getters will receive the state as their 1st argument:
 const store = createStore({
   state: {
     todos: [
-      { id: 1, text: "...", done: true },
-      { id: 2, text: "...", done: false },
-    ],
+      { id: 1, text: '...', done: true },
+      { id: 2, text: '...', done: false }
+    ]
   },
   getters: {
     doneTodos(state) {
-      return state.todos.filter((todo) => todo.done);
-    },
-  },
-});
+      return state.todos.filter((todo) => todo.done)
+    }
+  }
+})
 ```
 
 ## Property-Style Access
@@ -43,7 +43,7 @@ const store = createStore({
 The getters will be exposed on the `store.getters` object, and you access values as properties:
 
 ```js
-store.getters.doneTodos; // -> [{ id: 1, text: '...', done: true }]
+store.getters.doneTodos // -> [{ id: 1, text: '...', done: true }]
 ```
 
 Getters will also receive other getters as the 2nd argument:
@@ -58,7 +58,7 @@ getters: {
 ```
 
 ```js
-store.getters.doneTodosCount; // -> 1
+store.getters.doneTodosCount // -> 1
 ```
 
 We can now easily make use of it inside any component:
@@ -81,13 +81,13 @@ You can also pass arguments to getters by returning a function. This is particul
 getters: {
   // ...
   getTodoById: (state) => (id) => {
-    return state.todos.find((todo) => todo.id === id);
-  };
+    return state.todos.find((todo) => todo.id === id)
+  }
 }
 ```
 
 ```js
-store.getters.getTodoById(2); // -> { id: 2, text: '...', done: false }
+store.getters.getTodoById(2) // -> { id: 2, text: '...', done: false }
 ```
 
 Note that getters accessed via methods will run each time you call them, and the result is not cached.
@@ -97,19 +97,19 @@ Note that getters accessed via methods will run each time you call them, and the
 The `mapGetters` helper simply maps store getters to local computed properties:
 
 ```js
-import { mapGetters } from "vuex";
+import { mapGetters } from 'vuex'
 
 export default {
   // ...
   computed: {
     // mix the getters into computed with object spread operator
     ...mapGetters([
-      "doneTodosCount",
-      "anotherGetter",
+      'doneTodosCount',
+      'anotherGetter'
       // ...
-    ]),
-  },
-};
+    ])
+  }
+}
 ```
 
 If you want to map a getter to a different name, use an object:
@@ -143,15 +143,15 @@ export default {
 or object destructuring
 
 ```js
-import { useGetters } from "vuex";
+import { useGetters } from 'vuex'
 
 export default {
   setup() {
     return {
-      ...useGetters(["doneTodosCount", "anotherGetter"]),
-    };
-  },
-};
+      ...useGetters(['doneTodosCount', 'anotherGetter'])
+    }
+  }
+}
 ```
 
 You can learn more in the [Composition API](./composition-api#New-helper-methods-for-Composition-API) section.

--- a/docs/guide/mutations.md
+++ b/docs/guide/mutations.md
@@ -7,21 +7,21 @@ The only way to actually change state in a Vuex store is by committing a mutatio
 ```js
 const store = createStore({
   state: {
-    count: 1,
+    count: 1
   },
   mutations: {
     increment(state) {
       // mutate state
-      state.count++;
-    },
-  },
-});
+      state.count++
+    }
+  }
+})
 ```
 
 You cannot directly call a mutation handler. Think of it more like event registration: "When a mutation with type `increment` is triggered, call this handler." To invoke a mutation handler, you need to call `store.commit` with its type:
 
 ```js
-store.commit("increment");
+store.commit('increment')
 ```
 
 ## Commit with Payload
@@ -38,7 +38,7 @@ mutations: {
 ```
 
 ```js
-store.commit("increment", 10);
+store.commit('increment', 10)
 ```
 
 In most cases, the payload should be an object so that it can contain multiple fields, and the recorded mutation will also be more descriptive:
@@ -53,9 +53,9 @@ mutations: {
 ```
 
 ```js
-store.commit("increment", {
-  amount: 10,
-});
+store.commit('increment', {
+  amount: 10
+})
 ```
 
 ## Object-Style Commit
@@ -64,9 +64,9 @@ An alternative way to commit a mutation is by directly using an object that has 
 
 ```js
 store.commit({
-  type: "increment",
-  amount: 10,
-});
+  type: 'increment',
+  amount: 10
+})
 ```
 
 When using object-style commit, the entire object will be passed as the payload to mutation handlers, so the handler remains the same:
@@ -85,7 +85,7 @@ It is a commonly seen pattern to use constants for mutation types in various Flu
 
 ```js
 // mutation-types.js
-export const SOME_MUTATION = "SOME_MUTATION";
+export const SOME_MUTATION = 'SOME_MUTATION'
 ```
 
 ```js
@@ -128,22 +128,22 @@ Now imagine we are debugging the app and looking at the devtool's mutation logs.
 You can commit mutations in components with `this.$store.commit('xxx')`, or use the `mapMutations` helper which maps component methods to `store.commit` calls (requires root `store` injection):
 
 ```js
-import { mapMutations } from "vuex";
+import { mapMutations } from 'vuex'
 
 export default {
   // ...
   methods: {
     ...mapMutations([
-      "increment", // map `this.increment()` to `this.$store.commit('increment')`
+      'increment', // map `this.increment()` to `this.$store.commit('increment')`
 
       // `mapMutations` also supports payloads:
-      "incrementBy", // map `this.incrementBy(amount)` to `this.$store.commit('incrementBy', amount)`
+      'incrementBy' // map `this.incrementBy(amount)` to `this.$store.commit('incrementBy', amount)`
     ]),
     ...mapMutations({
-      add: "increment", // map `this.add()` to `this.$store.commit('increment')`
-    }),
-  },
-};
+      add: 'increment' // map `this.add()` to `this.$store.commit('increment')`
+    })
+  }
+}
 ```
 
 ## The `useMutations` Helper
@@ -167,15 +167,15 @@ export default {
 or object destructuring
 
 ```js
-import { useMutations } from "vuex";
+import { useMutations } from 'vuex'
 
 export default {
   setup() {
     return {
-      ...useMutations(["increment"]),
-    };
-  },
-};
+      ...useMutations(['increment'])
+    }
+  }
+}
 ```
 
 You can learn more in the [Composition API](./composition-api#New-helper-methods-for-Composition-API) section.
@@ -185,7 +185,7 @@ You can learn more in the [Composition API](./composition-api#New-helper-methods
 Asynchronicity combined with state mutation can make your program very hard to reason about. For example, when you call two methods both with async callbacks that mutate the state, how do you know when they are called and which callback was called first? This is exactly why we want to separate the two concepts. In Vuex, **mutations are synchronous transactions**:
 
 ```js
-store.commit("increment");
+store.commit('increment')
 // any state change that the "increment" mutation may cause
 // should be done at this moment.
 ```

--- a/docs/guide/mutations.md
+++ b/docs/guide/mutations.md
@@ -7,21 +7,21 @@ The only way to actually change state in a Vuex store is by committing a mutatio
 ```js
 const store = createStore({
   state: {
-    count: 1
+    count: 1,
   },
   mutations: {
-    increment (state) {
+    increment(state) {
       // mutate state
-      state.count++
-    }
-  }
-})
+      state.count++;
+    },
+  },
+});
 ```
 
 You cannot directly call a mutation handler. Think of it more like event registration: "When a mutation with type `increment` is triggered, call this handler." To invoke a mutation handler, you need to call `store.commit` with its type:
 
 ```js
-store.commit('increment')
+store.commit("increment");
 ```
 
 ## Commit with Payload
@@ -38,7 +38,7 @@ mutations: {
 ```
 
 ```js
-store.commit('increment', 10)
+store.commit("increment", 10);
 ```
 
 In most cases, the payload should be an object so that it can contain multiple fields, and the recorded mutation will also be more descriptive:
@@ -53,9 +53,9 @@ mutations: {
 ```
 
 ```js
-store.commit('increment', {
-  amount: 10
-})
+store.commit("increment", {
+  amount: 10,
+});
 ```
 
 ## Object-Style Commit
@@ -64,9 +64,9 @@ An alternative way to commit a mutation is by directly using an object that has 
 
 ```js
 store.commit({
-  type: 'increment',
-  amount: 10
-})
+  type: "increment",
+  amount: 10,
+});
 ```
 
 When using object-style commit, the entire object will be passed as the payload to mutation handlers, so the handler remains the same:
@@ -85,7 +85,7 @@ It is a commonly seen pattern to use constants for mutation types in various Flu
 
 ```js
 // mutation-types.js
-export const SOME_MUTATION = 'SOME_MUTATION'
+export const SOME_MUTATION = "SOME_MUTATION";
 ```
 
 ```js
@@ -128,30 +128,64 @@ Now imagine we are debugging the app and looking at the devtool's mutation logs.
 You can commit mutations in components with `this.$store.commit('xxx')`, or use the `mapMutations` helper which maps component methods to `store.commit` calls (requires root `store` injection):
 
 ```js
-import { mapMutations } from 'vuex'
+import { mapMutations } from "vuex";
 
 export default {
   // ...
   methods: {
     ...mapMutations([
-      'increment', // map `this.increment()` to `this.$store.commit('increment')`
+      "increment", // map `this.increment()` to `this.$store.commit('increment')`
 
       // `mapMutations` also supports payloads:
-      'incrementBy' // map `this.incrementBy(amount)` to `this.$store.commit('incrementBy', amount)`
+      "incrementBy", // map `this.incrementBy(amount)` to `this.$store.commit('incrementBy', amount)`
     ]),
     ...mapMutations({
-      add: 'increment' // map `this.add()` to `this.$store.commit('increment')`
-    })
-  }
-}
+      add: "increment", // map `this.add()` to `this.$store.commit('increment')`
+    }),
+  },
+};
 ```
+
+## The `useMutations` Helper
+
+This works the same way as the `mapMutations` helper but is compatible with the composition API `setup()` function.
+
+```js
+import { useMutations } from "vuex";
+
+export default {
+  setup() {
+
+    const { increment } = useMutations(["increment"])
+
+    return {
+      increment
+    };
+  },
+```
+
+or object destructuring
+
+```js
+import { useMutations } from "vuex";
+
+export default {
+  setup() {
+    return {
+      ...useMutations(["increment"]),
+    };
+  },
+};
+```
+
+You can learn more in the [Composition API](./composition-api#New-helper-methods-for-Composition-API) section.
 
 ## On to Actions
 
 Asynchronicity combined with state mutation can make your program very hard to reason about. For example, when you call two methods both with async callbacks that mutate the state, how do you know when they are called and which callback was called first? This is exactly why we want to separate the two concepts. In Vuex, **mutations are synchronous transactions**:
 
 ```js
-store.commit('increment')
+store.commit("increment");
 // any state change that the "increment" mutation may cause
 // should be done at this moment.
 ```

--- a/docs/guide/state.md
+++ b/docs/guide/state.md
@@ -20,10 +20,10 @@ const Counter = {
   template: `<div>{{ count }}</div>`,
   computed: {
     count() {
-      return store.state.count;
-    },
-  },
-};
+      return store.state.count
+    }
+  }
+}
 ```
 
 Whenever `store.state.count` changes, it will cause the computed property to re-evaluate, and trigger associated DOM updates.
@@ -37,10 +37,10 @@ const Counter = {
   template: `<div>{{ count }}</div>`,
   computed: {
     count() {
-      return this.$store.state.count;
-    },
-  },
-};
+      return this.$store.state.count
+    }
+  }
+}
 ```
 
 ## The `mapState` Helper
@@ -51,7 +51,7 @@ When a component needs to make use of multiple store state properties or getters
 
 ```js
 // in full builds helpers are exposed as Vuex.mapState
-import { mapState } from "vuex";
+import { mapState } from 'vuex'
 
 export default {
   // ...
@@ -60,14 +60,14 @@ export default {
     count: (state) => state.count,
 
     // passing the string value 'count' is same as `state => state.count`
-    countAlias: "count",
+    countAlias: 'count',
 
     // to access local state with `this`, a normal function must be used
     countPlusLocalState(state) {
-      return state.count + this.localCount;
-    },
-  }),
-};
+      return state.count + this.localCount
+    }
+  })
+}
 ```
 
 We can also pass a string array to `mapState` when the name of a mapped computed property is the same as a state sub tree name.
@@ -75,8 +75,8 @@ We can also pass a string array to `mapState` when the name of a mapped computed
 ```js
 computed: mapState([
   // map this.count to store.state.count
-  "count",
-]);
+  'count'
+])
 ```
 
 ## Object Spread Operator
@@ -114,15 +114,15 @@ export default {
 or object destructuring
 
 ```js
-import { useState } from "vuex";
+import { useState } from 'vuex'
 
 export default {
   setup() {
     return {
-      ...useState(["count"]),
-    };
-  },
-};
+      ...useState(['count'])
+    }
+  }
+}
 ```
 
 You can learn more in the [Composition API](./composition-api#New-helper-methods-for-Composition-API) section.

--- a/docs/guide/state.md
+++ b/docs/guide/state.md
@@ -19,11 +19,11 @@ So how do we display state inside the store in our Vue components? Since Vuex st
 const Counter = {
   template: `<div>{{ count }}</div>`,
   computed: {
-    count () {
-      return store.state.count
-    }
-  }
-}
+    count() {
+      return store.state.count;
+    },
+  },
+};
 ```
 
 Whenever `store.state.count` changes, it will cause the computed property to re-evaluate, and trigger associated DOM updates.
@@ -36,11 +36,11 @@ Vuex "injects" the store into all child components from the root component throu
 const Counter = {
   template: `<div>{{ count }}</div>`,
   computed: {
-    count () {
-      return this.$store.state.count
-    }
-  }
-}
+    count() {
+      return this.$store.state.count;
+    },
+  },
+};
 ```
 
 ## The `mapState` Helper
@@ -51,23 +51,23 @@ When a component needs to make use of multiple store state properties or getters
 
 ```js
 // in full builds helpers are exposed as Vuex.mapState
-import { mapState } from 'vuex'
+import { mapState } from "vuex";
 
 export default {
   // ...
   computed: mapState({
     // arrow functions can make the code very succinct!
-    count: state => state.count,
+    count: (state) => state.count,
 
     // passing the string value 'count' is same as `state => state.count`
-    countAlias: 'count',
+    countAlias: "count",
 
     // to access local state with `this`, a normal function must be used
-    countPlusLocalState (state) {
-      return state.count + this.localCount
-    }
-  })
-}
+    countPlusLocalState(state) {
+      return state.count + this.localCount;
+    },
+  }),
+};
 ```
 
 We can also pass a string array to `mapState` when the name of a mapped computed property is the same as a state sub tree name.
@@ -75,8 +75,8 @@ We can also pass a string array to `mapState` when the name of a mapped computed
 ```js
 computed: mapState([
   // map this.count to store.state.count
-  'count'
-])
+  "count",
+]);
 ```
 
 ## Object Spread Operator
@@ -92,6 +92,40 @@ computed: {
   })
 }
 ```
+
+## The `useState` Helper
+
+This works the same way as the `mapState` helper but is compatible with the composition API `setup()` function.
+
+```js
+import { useState } from "vuex";
+
+export default {
+  setup() {
+
+    const { count } = useState(["count"])
+
+    return {
+      count
+    };
+  },
+```
+
+or object destructuring
+
+```js
+import { useState } from "vuex";
+
+export default {
+  setup() {
+    return {
+      ...useState(["count"]),
+    };
+  },
+};
+```
+
+You can learn more in the [Composition API](./composition-api#New-helper-methods-for-Composition-API) section.
 
 ## Components Can Still Have Local State
 

--- a/examples/composition/chat-mappers/api/index.js
+++ b/examples/composition/chat-mappers/api/index.js
@@ -1,0 +1,24 @@
+const data = require('./mock-data')
+const LATENCY = 16
+
+export function getAllMessages (cb) {
+  setTimeout(() => {
+    cb(data)
+  }, LATENCY)
+}
+
+export function createMessage ({ text, thread }, cb) {
+  const timestamp = Date.now()
+  const id = 'm_' + timestamp
+  const message = {
+    id,
+    text,
+    timestamp,
+    threadID: thread.id,
+    threadName: thread.name,
+    authorName: 'Evan'
+  }
+  setTimeout(function () {
+    cb(message)
+  }, LATENCY)
+}

--- a/examples/composition/chat-mappers/api/mock-data.js
+++ b/examples/composition/chat-mappers/api/mock-data.js
@@ -1,0 +1,58 @@
+module.exports = [
+  {
+    id: 'm_1',
+    threadID: 't_1',
+    threadName: 'Jing and Bill',
+    authorName: 'Bill',
+    text: 'Hey Jing, want to give a Flux talk at ForwardJS?',
+    timestamp: Date.now() - 99999
+  },
+  {
+    id: 'm_2',
+    threadID: 't_1',
+    threadName: 'Jing and Bill',
+    authorName: 'Bill',
+    text: 'Seems like a pretty cool conference.',
+    timestamp: Date.now() - 89999
+  },
+  {
+    id: 'm_3',
+    threadID: 't_1',
+    threadName: 'Jing and Bill',
+    authorName: 'Jing',
+    text: 'Sounds good.  Will they be serving dessert?',
+    timestamp: Date.now() - 79999
+  },
+  {
+    id: 'm_4',
+    threadID: 't_2',
+    threadName: 'Dave and Bill',
+    authorName: 'Bill',
+    text: 'Hey Dave, want to get a beer after the conference?',
+    timestamp: Date.now() - 69999
+  },
+  {
+    id: 'm_5',
+    threadID: 't_2',
+    threadName: 'Dave and Bill',
+    authorName: 'Dave',
+    text: 'Totally!  Meet you at the hotel bar.',
+    timestamp: Date.now() - 59999
+  },
+  {
+    id: 'm_6',
+    threadID: 't_3',
+    threadName: 'Functional Heads',
+    authorName: 'Bill',
+    text: 'Hey Brian, are you going to be talking about functional stuff?',
+    timestamp: Date.now() - 49999
+  },
+  {
+    id: 'm_7',
+    threadID: 't_3',
+    threadName: 'Bill and Brian',
+    authorName: 'Brian',
+    text: 'At ForwardJS?  Yeah, of course.  See you there!',
+    timestamp: Date.now() - 39999
+  }
+]

--- a/examples/composition/chat-mappers/app.js
+++ b/examples/composition/chat-mappers/app.js
@@ -1,0 +1,12 @@
+import { createApp } from 'vue'
+import App from './components/App.vue'
+import store from './store'
+import { getAllMessages } from './store/actions'
+
+const app = createApp(App)
+
+app.use(store)
+
+app.mount('#app')
+
+getAllMessages(store)

--- a/examples/composition/chat-mappers/components/App.vue
+++ b/examples/composition/chat-mappers/components/App.vue
@@ -1,0 +1,21 @@
+<style src="../css/chat.css"></style>
+
+<template>
+  <div class="chatapp">
+    <thread-section></thread-section>
+    <message-section></message-section>
+  </div>
+</template>
+
+<script>
+import ThreadSection from "./ThreadSection.vue";
+import MessageSection from "./MessageSection.vue";
+
+export default {
+  name: "App",
+  components: {
+    ThreadSection,
+    MessageSection,
+  },
+};
+</script>

--- a/examples/composition/chat-mappers/components/App.vue
+++ b/examples/composition/chat-mappers/components/App.vue
@@ -8,14 +8,14 @@
 </template>
 
 <script>
-import ThreadSection from "./ThreadSection.vue";
-import MessageSection from "./MessageSection.vue";
+import ThreadSection from './ThreadSection.vue'
+import MessageSection from './MessageSection.vue'
 
 export default {
-  name: "App",
+  name: 'App',
   components: {
     ThreadSection,
-    MessageSection,
-  },
-};
+    MessageSection
+  }
+}
 </script>

--- a/examples/composition/chat-mappers/components/Message.vue
+++ b/examples/composition/chat-mappers/components/Message.vue
@@ -10,14 +10,14 @@
 
 <script>
 export default {
-  name: "Message",
+  name: 'Message',
   props: {
-    message: Object,
+    message: Object
   },
   setup() {
     return {
-      time: (value) => new Date(value).toLocaleTimeString(),
-    };
-  },
-};
+      time: (value) => new Date(value).toLocaleTimeString()
+    }
+  }
+}
 </script>

--- a/examples/composition/chat-mappers/components/Message.vue
+++ b/examples/composition/chat-mappers/components/Message.vue
@@ -1,0 +1,23 @@
+<template>
+  <li class="message-list-item">
+    <h5 class="message-author-name">{{ message.authorName }}</h5>
+    <div class="message-time">
+      {{ time(message.timestamp) }}
+    </div>
+    <div class="message-text">{{ message.text }}</div>
+  </li>
+</template>
+
+<script>
+export default {
+  name: "Message",
+  props: {
+    message: Object,
+  },
+  setup() {
+    return {
+      time: (value) => new Date(value).toLocaleTimeString(),
+    };
+  },
+};
+</script>

--- a/examples/composition/chat-mappers/components/MessageSection.vue
+++ b/examples/composition/chat-mappers/components/MessageSection.vue
@@ -1,0 +1,64 @@
+<template>
+  <div class="message-section">
+    <h3 class="message-thread-heading">{{ thread.name }}</h3>
+    <ul class="message-list" ref="list">
+      <message v-for="message in messages" :key="message.id" :message="message">
+      </message>
+    </ul>
+    <textarea
+      class="message-composer"
+      v-model="text"
+      @keyup.enter="sendMessage"
+    ></textarea>
+  </div>
+</template>
+
+<script>
+import { ref, watch, nextTick } from "vue";
+import { useGetters, useActions } from "vuex";
+import Message from "./Message.vue";
+
+export default {
+  name: "MessageSection",
+  components: { Message },
+  setup() {
+    const list = ref(null);
+
+    const text = ref("");
+
+    const { thread, messages } = useGetters([
+      "currentThread",
+      "sortedMessages",
+    ]);
+    const { sendMessageAction } = useActions({
+      sendMessageAction: "sendMessage",
+    });
+
+    watch(
+      () => thread.value.lastMessage,
+      () => {
+        nextTick(() => {
+          const ul = list.value;
+          ul.scrollTop = ul.scrollHeight;
+        });
+      }
+    );
+
+    function sendMessage() {
+      const trimedText = text.value.trim();
+      if (trimedText) {
+        sendMessageAction(trimedText, thread);
+        this.text = "";
+      }
+    }
+
+    return {
+      list,
+      text,
+      thread,
+      messages,
+      sendMessage,
+    };
+  },
+};
+</script>

--- a/examples/composition/chat-mappers/components/MessageSection.vue
+++ b/examples/composition/chat-mappers/components/MessageSection.vue
@@ -14,41 +14,38 @@
 </template>
 
 <script>
-import { ref, watch, nextTick } from "vue";
-import { useGetters, useActions } from "vuex";
-import Message from "./Message.vue";
+import { ref, watch, nextTick } from 'vue'
+import { useGetters, useActions } from 'vuex'
+import Message from './Message.vue'
 
 export default {
-  name: "MessageSection",
+  name: 'MessageSection',
   components: { Message },
   setup() {
-    const list = ref(null);
+    const list = ref(null)
 
-    const text = ref("");
+    const text = ref('')
 
-    const { thread, messages } = useGetters([
-      "currentThread",
-      "sortedMessages",
-    ]);
+    const { thread, messages } = useGetters(['currentThread', 'sortedMessages'])
     const { sendMessageAction } = useActions({
-      sendMessageAction: "sendMessage",
-    });
+      sendMessageAction: 'sendMessage'
+    })
 
     watch(
       () => thread.value.lastMessage,
       () => {
         nextTick(() => {
-          const ul = list.value;
-          ul.scrollTop = ul.scrollHeight;
-        });
+          const ul = list.value
+          ul.scrollTop = ul.scrollHeight
+        })
       }
-    );
+    )
 
     function sendMessage() {
-      const trimedText = text.value.trim();
+      const trimedText = text.value.trim()
       if (trimedText) {
-        sendMessageAction(trimedText, thread);
-        this.text = "";
+        sendMessageAction(trimedText, thread)
+        this.text = ''
       }
     }
 
@@ -57,8 +54,8 @@ export default {
       text,
       thread,
       messages,
-      sendMessage,
-    };
-  },
-};
+      sendMessage
+    }
+  }
+}
 </script>

--- a/examples/composition/chat-mappers/components/Thread.vue
+++ b/examples/composition/chat-mappers/components/Thread.vue
@@ -2,7 +2,8 @@
   <li
     class="thread-list-item"
     :class="{ active }"
-    @click="$emit('switch-thread', thread.id)">
+    @click="$emit('switch-thread', thread.id)"
+  >
     <h5 class="thread-name">{{ thread.name }}</h5>
     <div class="thread-time">
       {{ time(thread.lastMessage.timestamp) }}
@@ -20,9 +21,9 @@ export default {
     thread: Object,
     active: Boolean
   },
-  setup () {
+  setup() {
     return {
-      time: value => new Date(value).toLocaleTimeString()
+      time: (value) => new Date(value).toLocaleTimeString()
     }
   }
 }

--- a/examples/composition/chat-mappers/components/Thread.vue
+++ b/examples/composition/chat-mappers/components/Thread.vue
@@ -1,0 +1,29 @@
+<template>
+  <li
+    class="thread-list-item"
+    :class="{ active }"
+    @click="$emit('switch-thread', thread.id)">
+    <h5 class="thread-name">{{ thread.name }}</h5>
+    <div class="thread-time">
+      {{ time(thread.lastMessage.timestamp) }}
+    </div>
+    <div class="thread-last-message">
+      {{ thread.lastMessage.text }}
+    </div>
+  </li>
+</template>
+
+<script>
+export default {
+  name: 'Thread',
+  props: {
+    thread: Object,
+    active: Boolean
+  },
+  setup () {
+    return {
+      time: value => new Date(value).toLocaleTimeString()
+    }
+  }
+}
+</script>

--- a/examples/composition/chat-mappers/components/ThreadSection.vue
+++ b/examples/composition/chat-mappers/components/ThreadSection.vue
@@ -17,18 +17,17 @@
 </template>
 
 <script>
-import { computed } from "vue";
-import { useGetters, useActions } from "vuex";
-import Thread from "./Thread.vue";
+import { useGetters, useActions } from 'vuex'
+import Thread from './Thread.vue'
 
 export default {
-  name: "ThreadSection",
+  name: 'ThreadSection',
   components: { Thread },
   setup() {
     return {
-      ...useGetters(["threads", "currentThread", "unreadCount"]),
-      ...useActions(["switchThread"]),
-    };
-  },
-};
+      ...useGetters(['threads', 'currentThread', 'unreadCount']),
+      ...useActions(['switchThread'])
+    }
+  }
+}
 </script>

--- a/examples/composition/chat-mappers/components/ThreadSection.vue
+++ b/examples/composition/chat-mappers/components/ThreadSection.vue
@@ -1,0 +1,34 @@
+<template>
+  <div class="thread-section">
+    <div class="thread-count">
+      <span v-show="unreadCount"> Unread threads: {{ unreadCount }} </span>
+    </div>
+    <ul class="thread-list">
+      <thread
+        v-for="thread in threads"
+        :key="thread.id"
+        :thread="thread"
+        :active="thread.id === currentThread.id"
+        @switch-thread="switchThread"
+      >
+      </thread>
+    </ul>
+  </div>
+</template>
+
+<script>
+import { computed } from "vue";
+import { useGetters, useActions } from "vuex";
+import Thread from "./Thread.vue";
+
+export default {
+  name: "ThreadSection",
+  components: { Thread },
+  setup() {
+    return {
+      ...useGetters(["threads", "currentThread", "unreadCount"]),
+      ...useActions(["switchThread"]),
+    };
+  },
+};
+</script>

--- a/examples/composition/chat-mappers/css/chat.css
+++ b/examples/composition/chat-mappers/css/chat.css
@@ -1,0 +1,98 @@
+/**
+ * This file is provided by Facebook for testing and evaluation purposes
+ * only. Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+.chatapp {
+  font-family: 'Muli', 'Helvetica Neue', helvetica, arial;
+  max-width: 760px;
+  margin: 20px auto;
+  overflow: hidden;
+}
+
+.message-list, .thread-list {
+  border: 1px solid #ccf;
+  font-size: 16px;
+  height: 400px;
+  margin: 0;
+  overflow-y: auto;
+  padding: 0;
+}
+
+.message-section {
+  float: right;
+  width: 65%;
+}
+
+.thread-section {
+  float: left;
+  width: 32.5%;
+}
+
+.message-thread-heading,
+.thread-count {
+  height: 40px;
+  margin: 0;
+}
+
+.message-list-item, .thread-list-item {
+  list-style: none;
+  padding: 12px 14px 14px;
+}
+
+.thread-list-item {
+  border-bottom: 1px solid #ccc;
+  cursor: pointer;
+}
+
+.thread-list:hover .thread-list-item:hover {
+  background-color: #f8f8ff;
+}
+
+.thread-list:hover .thread-list-item {
+  background-color: #fff;
+}
+
+.thread-list-item.active,
+.thread-list:hover .thread-list-item.active,
+.thread-list:hover .thread-list-item.active:hover {
+  background-color: #efefff;
+  cursor: default;
+}
+
+.message-author-name,
+.thread-name {
+  color: #66c;
+  float: left;
+  font-size: 13px;
+  margin: 0;
+}
+
+.message-time, .thread-time {
+  color: #aad;
+  float: right;
+  font-size: 12px;
+}
+
+.message-text, .thread-last-message {
+  clear: both;
+  font-size: 14px;
+  padding-top: 10px;
+}
+
+.message-composer {
+  box-sizing: border-box;
+  font-family: inherit;
+  font-size: 14px;
+  height: 5em;
+  width: 100%;
+  margin: 20px 0 0;
+  padding: 10px;
+}

--- a/examples/composition/chat-mappers/index.html
+++ b/examples/composition/chat-mappers/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>vuex chat example</title>
+    <link href="http://fonts.googleapis.com/css?family=Muli" rel="stylesheet" type="text/css">
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="/__build__/shared.js"></script>
+    <script src="/__build__/composition/chat.js"></script>
+  </body>
+</html>

--- a/examples/composition/chat-mappers/store/actions.js
+++ b/examples/composition/chat-mappers/store/actions.js
@@ -1,0 +1,17 @@
+import * as api from '../api'
+
+export const getAllMessages = ({ commit }) => {
+  api.getAllMessages(messages => {
+    commit('receiveAll', messages)
+  })
+}
+
+export const sendMessage = ({ commit }, payload) => {
+  api.createMessage(payload, message => {
+    commit('receiveMessage', message)
+  })
+}
+
+export const switchThread = ({ commit }, payload) => {
+  commit('switchThread', payload)
+}

--- a/examples/composition/chat-mappers/store/getters.js
+++ b/examples/composition/chat-mappers/store/getters.js
@@ -1,0 +1,25 @@
+export const threads = state => state.threads
+
+export const currentThread = state => {
+  return state.currentThreadID
+    ? state.threads[state.currentThreadID]
+    : {}
+}
+
+export const currentMessages = state => {
+  const thread = currentThread(state)
+  return thread.messages
+    ? thread.messages.map(id => state.messages[id])
+    : []
+}
+
+export const unreadCount = ({ threads }) => {
+  return Object.keys(threads).reduce((count, id) => {
+    return threads[id].lastMessage.isRead ? count : count + 1
+  }, 0)
+}
+
+export const sortedMessages = (state, getters) => {
+  const messages = getters.currentMessages
+  return messages.slice().sort((a, b) => a.timestamp - b.timestamp)
+}

--- a/examples/composition/chat-mappers/store/index.js
+++ b/examples/composition/chat-mappers/store/index.js
@@ -1,0 +1,41 @@
+import { createStore, createLogger } from 'vuex'
+import * as getters from './getters'
+import * as actions from './actions'
+import mutations from './mutations'
+
+const state = {
+  currentThreadID: null,
+  threads: {
+    /*
+    id: {
+      id,
+      name,
+      messages: [...ids],
+      lastMessage
+    }
+    */
+  },
+  messages: {
+    /*
+    id: {
+      id,
+      threadId,
+      threadName,
+      authorName,
+      text,
+      timestamp,
+      isRead
+    }
+    */
+  }
+}
+
+export default createStore({
+  state,
+  getters,
+  actions,
+  mutations,
+  plugins: process.env.NODE_ENV !== 'production'
+    ? [createLogger()]
+    : []
+})

--- a/examples/composition/chat-mappers/store/mutations.js
+++ b/examples/composition/chat-mappers/store/mutations.js
@@ -1,0 +1,64 @@
+export default {
+  receiveAll (state, messages) {
+    let latestMessage
+    messages.forEach(message => {
+      // create new thread if the thread doesn't exist
+      if (!state.threads[message.threadID]) {
+        createThread(state, message.threadID, message.threadName)
+      }
+      // mark the latest message
+      if (!latestMessage || message.timestamp > latestMessage.timestamp) {
+        latestMessage = message
+      }
+      // add message
+      addMessage(state, message)
+    })
+    // set initial thread to the one with the latest message
+    setCurrentThread(state, latestMessage.threadID)
+  },
+
+  receiveMessage (state, message) {
+    addMessage(state, message)
+  },
+
+  switchThread (state, id) {
+    setCurrentThread(state, id)
+  }
+}
+
+function createThread (state, id, name) {
+  state.threads = {
+    ...state.threads,
+    [id]: {
+      id,
+      name,
+      messages: [],
+      lastMessage: null
+    }
+  }
+}
+
+function addMessage (state, message) {
+  // add a `isRead` field before adding the message
+  message.isRead = message.threadID === state.currentThreadID
+  // add it to the thread it belongs to
+  const thread = state.threads[message.threadID]
+  if (!thread.messages.some(id => id === message.id)) {
+    thread.messages.push(message.id)
+    thread.lastMessage = message
+  }
+  // add it to the messages map
+  state.messages = {
+    ...state.messages,
+    [message.id]: message
+  }
+}
+
+function setCurrentThread (state, id) {
+  state.currentThreadID = id
+  if (!state.threads[id]) {
+    debugger
+  }
+  // mark thread as read
+  state.threads[id].lastMessage.isRead = true
+}

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>Vuex Examples</title>
-    <link rel="stylesheet" href="/global.css">
+    <link rel="stylesheet" href="/global.css" />
   </head>
   <body style="padding: 0 20px">
     <h1>Vuex Examples</h1>
@@ -26,6 +26,9 @@
       <li><a href="composition/shopping-cart">Shopping Cart</a></li>
       <li><a href="composition/todomvc">TodoMVC</a></li>
       <li><a href="composition/chat">FluxChat</a></li>
+      <li>
+        <a href="composition/chat-mappers">FluxChat with new Vuex mappers</a>
+      </li>
     </ul>
   </body>
 </html>

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,6 +1,6 @@
-import { isObject } from "./util";
-import { useStore } from "./injectKey";
-import { computed } from "vue";
+import { isObject } from './util'
+import { useStore } from './injectKey'
+import { computed } from 'vue'
 
 /**
  * Reduce the code which written in Vue.js for getting the state.
@@ -9,33 +9,31 @@ import { computed } from "vue";
  * @param {Object}
  */
 export const mapState = normalizeNamespace((namespace, states) => {
-  const res = {};
+  const res = {}
   if (__DEV__ && !isValidMap(states)) {
     console.error(
-      "[vuex] mapState: mapper parameter must be either an Array or an Object"
-    );
+      '[vuex] mapState: mapper parameter must be either an Array or an Object'
+    )
   }
   normalizeMap(states).forEach(({ key, val }) => {
     res[key] = function mappedState() {
-      let state = this.$store.state;
-      let getters = this.$store.getters;
+      let state = this.$store.state
+      let getters = this.$store.getters
       if (namespace) {
-        const module = getModuleByNamespace(this.$store, "mapState", namespace);
+        const module = getModuleByNamespace(this.$store, 'mapState', namespace)
         if (!module) {
-          return;
+          return
         }
-        state = module.context.state;
-        getters = module.context.getters;
+        state = module.context.state
+        getters = module.context.getters
       }
-      return typeof val === "function"
-        ? val.call(this, state, getters)
-        : state[val];
-    };
+      return typeof val === 'function' ? val.call(this, state, getters) : state[val]
+    }
     // mark vuex getter for devtools
-    res[key].vuex = true;
-  });
-  return res;
-});
+    res[key].vuex = true
+  })
+  return res
+})
 
 /**
  * Reduce the code which written in Vue.js for getting the state.
@@ -44,34 +42,32 @@ export const mapState = normalizeNamespace((namespace, states) => {
  * @param {Object}
  */
 export const useState = normalizeNamespace((namespace, states) => {
-  const res = {};
+  const res = {}
   if (__DEV__ && !isValidMap(states)) {
     console.error(
-      "[vuex] mapState: mapper parameter must be either an Array or an Object"
-    );
+      '[vuex] mapState: mapper parameter must be either an Array or an Object'
+    )
   }
-  const store = useStore();
-  let state = store.state;
-  let getters = store.getters;
+  const store = useStore()
+  let state = store.state
+  let getters = store.getters
   if (namespace) {
-    const module = getModuleByNamespace(store, "mapState", namespace);
+    const module = getModuleByNamespace(store, 'mapState', namespace)
     if (!module) {
-      return;
+      return
     }
-    state = module.context.state;
-    getters = module.context.getters;
+    state = module.context.state
+    getters = module.context.getters
   }
   normalizeMap(states).forEach(({ key, val }) => {
     res[key] = computed(() => {
-      return typeof val === "function"
-        ? val.call(null, state, getters)
-        : state[val];
-    });
+      return typeof val === 'function' ? val.call(null, state, getters) : state[val]
+    })
     // mark vuex getter for devtools
-    res[key].vuex = true;
-  });
-  return res;
-});
+    res[key].vuex = true
+  })
+  return res
+})
 
 /**
  * Reduce the code which written in Vue.js for committing the mutation
@@ -80,34 +76,30 @@ export const useState = normalizeNamespace((namespace, states) => {
  * @return {Object}
  */
 export const mapMutations = normalizeNamespace((namespace, mutations) => {
-  const res = {};
+  const res = {}
   if (__DEV__ && !isValidMap(mutations)) {
     console.error(
-      "[vuex] mapMutations: mapper parameter must be either an Array or an Object"
-    );
+      '[vuex] mapMutations: mapper parameter must be either an Array or an Object'
+    )
   }
   normalizeMap(mutations).forEach(({ key, val }) => {
     res[key] = function mappedMutation(...args) {
       // Get the commit method from store
-      let commit = this.$store.commit;
+      let commit = this.$store.commit
       if (namespace) {
-        const module = getModuleByNamespace(
-          this.$store,
-          "mapMutations",
-          namespace
-        );
+        const module = getModuleByNamespace(this.$store, 'mapMutations', namespace)
         if (!module) {
-          return;
+          return
         }
-        commit = module.context.commit;
+        commit = module.context.commit
       }
-      return typeof val === "function"
+      return typeof val === 'function'
         ? val.apply(this, [commit].concat(args))
-        : commit.apply(this.$store, [val].concat(args));
-    };
-  });
-  return res;
-});
+        : commit.apply(this.$store, [val].concat(args))
+    }
+  })
+  return res
+})
 /**
  * Reduce the code which written in Vue.js for committing the mutation
  * @param {String} [namespace] - Module's namespace
@@ -115,30 +107,30 @@ export const mapMutations = normalizeNamespace((namespace, mutations) => {
  * @return {Object}
  */
 export const useMutations = normalizeNamespace((namespace, mutations) => {
-  const res = {};
+  const res = {}
   if (__DEV__ && !isValidMap(mutations)) {
     console.error(
-      "[vuex] mapMutations: mapper parameter must be either an Array or an Object"
-    );
+      '[vuex] mapMutations: mapper parameter must be either an Array or an Object'
+    )
   }
   // Get the commit method from store
-  const store = useStore();
-  let commit = store.commit;
+  const store = useStore()
+  let commit = store.commit
   if (namespace) {
-    const module = getModuleByNamespace(store, "mapMutations", namespace);
+    const module = getModuleByNamespace(store, 'mapMutations', namespace)
     if (!module) {
-      return;
+      return
     }
-    commit = module.context.commit;
+    commit = module.context.commit
   }
   normalizeMap(mutations).forEach(({ key, val }) => {
     res[key] = (...args) =>
-      typeof val === "function"
+      typeof val === 'function'
         ? val.apply(null, [commit].concat(args))
-        : commit.apply(store, [val].concat(args));
-  });
-  return res;
-});
+        : commit.apply(store, [val].concat(args))
+  })
+  return res
+})
 
 /**
  * Reduce the code which written in Vue.js for getting the getters
@@ -147,33 +139,30 @@ export const useMutations = normalizeNamespace((namespace, mutations) => {
  * @return {Object}
  */
 export const mapGetters = normalizeNamespace((namespace, getters) => {
-  const res = {};
+  const res = {}
   if (__DEV__ && !isValidMap(getters)) {
     console.error(
-      "[vuex] mapGetters: mapper parameter must be either an Array or an Object"
-    );
+      '[vuex] mapGetters: mapper parameter must be either an Array or an Object'
+    )
   }
   normalizeMap(getters).forEach(({ key, val }) => {
     // The namespace has been mutated by normalizeNamespace
-    val = namespace + val;
+    val = namespace + val
     res[key] = function mappedGetter() {
-      if (
-        namespace &&
-        !getModuleByNamespace(this.$store, "mapGetters", namespace)
-      ) {
-        return;
+      if (namespace && !getModuleByNamespace(this.$store, 'mapGetters', namespace)) {
+        return
       }
       if (__DEV__ && !(val in this.$store.getters)) {
-        console.error(`[vuex] unknown getter: ${val}`);
-        return;
+        console.error(`[vuex] unknown getter: ${val}`)
+        return
       }
-      return this.$store.getters[val];
-    };
+      return this.$store.getters[val]
+    }
     // mark vuex getter for devtools
-    res[key].vuex = true;
-  });
-  return res;
-});
+    res[key].vuex = true
+  })
+  return res
+})
 
 /**
  * Reduce the code which written in Vue.js for getting the getters
@@ -182,31 +171,31 @@ export const mapGetters = normalizeNamespace((namespace, getters) => {
  * @return {Object}
  */
 export const useGetters = normalizeNamespace((namespace, getters) => {
-  const res = {};
-  const store = useStore();
+  const res = {}
+  const store = useStore()
   if (__DEV__ && !isValidMap(getters)) {
     console.error(
-      "[vuex] mapGetters: mapper parameter must be either an Array or an Object"
-    );
+      '[vuex] mapGetters: mapper parameter must be either an Array or an Object'
+    )
   }
   normalizeMap(getters).forEach(({ key, val }) => {
     // The namespace has been mutated by normalizeNamespace
-    val = namespace + val;
+    val = namespace + val
     res[key] = computed(() => {
-      if (namespace && !getModuleByNamespace(store, "mapGetters", namespace)) {
-        return;
+      if (namespace && !getModuleByNamespace(store, 'mapGetters', namespace)) {
+        return
       }
       if (__DEV__ && !(val in store.getters)) {
-        console.error(`[vuex] unknown getter: ${val}`);
-        return;
+        console.error(`[vuex] unknown getter: ${val}`)
+        return
       }
-      return store.getters[val];
-    });
+      return store.getters[val]
+    })
     // mark vuex getter for devtools
-    res[key].vuex = true;
-  });
-  return res;
-});
+    res[key].vuex = true
+  })
+  return res
+})
 
 /**
  * Reduce the code which written in Vue.js for dispatch the action
@@ -215,34 +204,30 @@ export const useGetters = normalizeNamespace((namespace, getters) => {
  * @return {Object}
  */
 export const mapActions = normalizeNamespace((namespace, actions) => {
-  const res = {};
+  const res = {}
   if (__DEV__ && !isValidMap(actions)) {
     console.error(
-      "[vuex] mapActions: mapper parameter must be either an Array or an Object"
-    );
+      '[vuex] mapActions: mapper parameter must be either an Array or an Object'
+    )
   }
   normalizeMap(actions).forEach(({ key, val }) => {
     res[key] = function mappedAction(...args) {
       // get dispatch function from store
-      let dispatch = this.$store.dispatch;
+      let dispatch = this.$store.dispatch
       if (namespace) {
-        const module = getModuleByNamespace(
-          this.$store,
-          "mapActions",
-          namespace
-        );
+        const module = getModuleByNamespace(this.$store, 'mapActions', namespace)
         if (!module) {
-          return;
+          return
         }
-        dispatch = module.context.dispatch;
+        dispatch = module.context.dispatch
       }
-      return typeof val === "function"
+      return typeof val === 'function'
         ? val.apply(this, [dispatch].concat(args))
-        : dispatch.apply(this.$store, [val].concat(args));
-    };
-  });
-  return res;
-});
+        : dispatch.apply(this.$store, [val].concat(args))
+    }
+  })
+  return res
+})
 
 /**
  * Reduce the code which written in Vue.js for dispatch the action
@@ -251,31 +236,31 @@ export const mapActions = normalizeNamespace((namespace, actions) => {
  * @return {Object}
  */
 export const useActions = normalizeNamespace((namespace, actions) => {
-  const res = {};
+  const res = {}
   if (__DEV__ && !isValidMap(actions)) {
     console.error(
-      "[vuex] mapActions: mapper parameter must be either an Array or an Object"
-    );
+      '[vuex] mapActions: mapper parameter must be either an Array or an Object'
+    )
   }
   // get dispatch function from store
-  const store = useStore();
-  let dispatch = store.dispatch;
+  const store = useStore()
+  let dispatch = store.dispatch
   if (namespace) {
-    const module = getModuleByNamespace(store, "mapActions", namespace);
+    const module = getModuleByNamespace(store, 'mapActions', namespace)
     if (!module) {
-      return;
+      return
     }
-    dispatch = module.context.dispatch;
+    dispatch = module.context.dispatch
   }
   normalizeMap(actions).forEach(({ key, val }) => {
     res[key] = (...args) => {
-      return typeof val === "function"
+      return typeof val === 'function'
         ? val.apply(null, [dispatch].concat(args))
-        : dispatch.apply(store, [val].concat(args));
-    };
-  });
-  return res;
-});
+        : dispatch.apply(store, [val].concat(args))
+    }
+  })
+  return res
+})
 
 /**
  * Rebinding namespace param for mapXXX function in special scoped, and return them by simple object
@@ -286,8 +271,8 @@ export const createNamespacedHelpers = (namespace) => ({
   mapState: mapState.bind(null, namespace),
   mapGetters: mapGetters.bind(null, namespace),
   mapMutations: mapMutations.bind(null, namespace),
-  mapActions: mapActions.bind(null, namespace),
-});
+  mapActions: mapActions.bind(null, namespace)
+})
 
 /**
  * Normalize the map
@@ -298,11 +283,11 @@ export const createNamespacedHelpers = (namespace) => ({
  */
 function normalizeMap(map) {
   if (!isValidMap(map)) {
-    return [];
+    return []
   }
   return Array.isArray(map)
     ? map.map((key) => ({ key, val: key }))
-    : Object.keys(map).map((key) => ({ key, val: map[key] }));
+    : Object.keys(map).map((key) => ({ key, val: map[key] }))
 }
 
 /**
@@ -311,7 +296,7 @@ function normalizeMap(map) {
  * @return {Boolean}
  */
 function isValidMap(map) {
-  return Array.isArray(map) || isObject(map);
+  return Array.isArray(map) || isObject(map)
 }
 
 /**
@@ -321,14 +306,14 @@ function isValidMap(map) {
  */
 function normalizeNamespace(fn) {
   return (namespace, map) => {
-    if (typeof namespace !== "string") {
-      map = namespace;
-      namespace = "";
-    } else if (namespace.charAt(namespace.length - 1) !== "/") {
-      namespace += "/";
+    if (typeof namespace !== 'string') {
+      map = namespace
+      namespace = ''
+    } else if (namespace.charAt(namespace.length - 1) !== '/') {
+      namespace += '/'
     }
-    return fn(namespace, map);
-  };
+    return fn(namespace, map)
+  }
 }
 
 /**
@@ -339,11 +324,9 @@ function normalizeNamespace(fn) {
  * @return {Object}
  */
 function getModuleByNamespace(store, helper, namespace) {
-  const module = store._modulesNamespaceMap[namespace];
+  const module = store._modulesNamespaceMap[namespace]
   if (__DEV__ && !module) {
-    console.error(
-      `[vuex] module namespace not found in ${helper}(): ${namespace}`
-    );
+    console.error(`[vuex] module namespace not found in ${helper}(): ${namespace}`)
   }
-  return module;
+  return module
 }

--- a/src/index.cjs.js
+++ b/src/index.cjs.js
@@ -1,5 +1,5 @@
-import { Store, createStore } from "./store";
-import { storeKey, useStore } from "./injectKey";
+import { Store, createStore } from './store'
+import { storeKey, useStore } from './injectKey'
 import {
   mapState,
   mapMutations,
@@ -9,12 +9,12 @@ import {
   useState,
   useMutations,
   useGetters,
-  useActions,
-} from "./helpers";
-import { createLogger } from "./plugins/logger";
+  useActions
+} from './helpers'
+import { createLogger } from './plugins/logger'
 
 export default {
-  version: "__VERSION__",
+  version: '__VERSION__',
   Store,
   storeKey,
   createStore,
@@ -28,5 +28,5 @@ export default {
   useGetters,
   useActions,
   createNamespacedHelpers,
-  createLogger,
-};
+  createLogger
+}

--- a/src/index.cjs.js
+++ b/src/index.cjs.js
@@ -1,10 +1,20 @@
-import { Store, createStore } from './store'
-import { storeKey, useStore } from './injectKey'
-import { mapState, mapMutations, mapGetters, mapActions, createNamespacedHelpers } from './helpers'
-import { createLogger } from './plugins/logger'
+import { Store, createStore } from "./store";
+import { storeKey, useStore } from "./injectKey";
+import {
+  mapState,
+  mapMutations,
+  mapGetters,
+  mapActions,
+  createNamespacedHelpers,
+  useState,
+  useMutations,
+  useGetters,
+  useActions,
+} from "./helpers";
+import { createLogger } from "./plugins/logger";
 
 export default {
-  version: '__VERSION__',
+  version: "__VERSION__",
   Store,
   storeKey,
   createStore,
@@ -13,6 +23,10 @@ export default {
   mapMutations,
   mapGetters,
   mapActions,
+  useState,
+  useMutations,
+  useGetters,
+  useActions,
   createNamespacedHelpers,
-  createLogger
-}
+  createLogger,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
-import { Store, createStore } from "./store";
-import { storeKey, useStore } from "./injectKey";
+import { Store, createStore } from './store'
+import { storeKey, useStore } from './injectKey'
 import {
   mapState,
   mapMutations,
@@ -9,12 +9,12 @@ import {
   useMutations,
   useGetters,
   useActions,
-  createNamespacedHelpers,
-} from "./helpers";
-import { createLogger } from "./plugins/logger";
+  createNamespacedHelpers
+} from './helpers'
+import { createLogger } from './plugins/logger'
 
 export default {
-  version: "__VERSION__",
+  version: '__VERSION__',
   Store,
   storeKey,
   createStore,
@@ -28,8 +28,8 @@ export default {
   useGetters,
   useActions,
   createNamespacedHelpers,
-  createLogger,
-};
+  createLogger
+}
 
 export {
   Store,
@@ -45,5 +45,5 @@ export {
   useGetters,
   useActions,
   createNamespacedHelpers,
-  createLogger,
-};
+  createLogger
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,20 @@
-import { Store, createStore } from './store'
-import { storeKey, useStore } from './injectKey'
-import { mapState, mapMutations, mapGetters, mapActions, createNamespacedHelpers } from './helpers'
-import { createLogger } from './plugins/logger'
+import { Store, createStore } from "./store";
+import { storeKey, useStore } from "./injectKey";
+import {
+  mapState,
+  mapMutations,
+  mapGetters,
+  mapActions,
+  useState,
+  useMutations,
+  useGetters,
+  useActions,
+  createNamespacedHelpers,
+} from "./helpers";
+import { createLogger } from "./plugins/logger";
 
 export default {
-  version: '__VERSION__',
+  version: "__VERSION__",
   Store,
   storeKey,
   createStore,
@@ -13,9 +23,13 @@ export default {
   mapMutations,
   mapGetters,
   mapActions,
+  useState,
+  useMutations,
+  useGetters,
+  useActions,
   createNamespacedHelpers,
-  createLogger
-}
+  createLogger,
+};
 
 export {
   Store,
@@ -26,6 +40,10 @@ export {
   mapMutations,
   mapGetters,
   mapActions,
+  useState,
+  useMutations,
+  useGetters,
+  useActions,
   createNamespacedHelpers,
-  createLogger
-}
+  createLogger,
+};

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,4 +1,4 @@
-import Vuex from "../dist/vuex.cjs.js";
+import Vuex from '../dist/vuex.cjs.js'
 
 const {
   version,
@@ -16,8 +16,8 @@ const {
   useGetters,
   useActions,
   createNamespacedHelpers,
-  createLogger,
-} = Vuex;
+  createLogger
+} = Vuex
 
 export {
   Vuex as default,
@@ -36,5 +36,5 @@ export {
   useGetters,
   useActions,
   createNamespacedHelpers,
-  createLogger,
-};
+  createLogger
+}

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,4 +1,4 @@
-import Vuex from '../dist/vuex.cjs.js'
+import Vuex from "../dist/vuex.cjs.js";
 
 const {
   version,
@@ -11,9 +11,13 @@ const {
   mapMutations,
   mapGetters,
   mapActions,
+  useState,
+  useMutations,
+  useGetters,
+  useActions,
   createNamespacedHelpers,
-  createLogger
-} = Vuex
+  createLogger,
+} = Vuex;
 
 export {
   Vuex as default,
@@ -27,6 +31,10 @@ export {
   mapMutations,
   mapGetters,
   mapActions,
+  useState,
+  useMutations,
+  useGetters,
+  useActions,
   createNamespacedHelpers,
-  createLogger
-}
+  createLogger,
+};


### PR DESCRIPTION
The `useXXX` helpers are not meant to replace the `mapXXX` helper but to bring compatibility to the `setup()` function when using the composition API as seen in issue #1725.

Basic usage:
```js
import { useState } from "vuex";

export default {
  setup() {

    const { count } = useState(["count"])

    return {
      count
    }
  }
```

```js
import { useState } from 'vuex'

export default {
  setup() {
    return {
      ...useState(['count'])
    }
  }
}
```

Giving a property an alias:

```js
import { useState } from 'vuex'
export default {
  setup() {
    return {
      ...useState({ countAlias: 'count' })
    }
  }
}
```

Using namespaced modules:
```js
import { useState } from 'vuex'
export default {
  setup() {
    return {
      ...useState('moduleB', [ 'count' ])
    }
  }
}
```

