### PR TITLE
Return a new rejected promise instead of throwing an error in the action error handler for devtools

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -485,7 +485,7 @@ function registerAction (store, type, handler, local) {
     if (store._devtoolHook) {
       return res.catch(err => {
         store._devtoolHook.emit('vuex:error', err)
-        throw err
+        return Promise.reject(error)
       })
     } else {
       return res

--- a/src/store.js
+++ b/src/store.js
@@ -485,7 +485,7 @@ function registerAction (store, type, handler, local) {
     if (store._devtoolHook) {
       return res.catch(err => {
         store._devtoolHook.emit('vuex:error', err)
-        return Promise.reject(error)
+        return Promise.reject(err)
       })
     } else {
       return res


### PR DESCRIPTION
Fixes #1969 - refer to this issue for background and demo.

This change only affects the developer experience, and only when using the Vue devtools extension (as far as I can tell); it relates to code that is only called when `store._devtoolHook` is defined.

The code in question deals with catching errors in action promises, so that the devtools hook can be notified by emitting an event. Catching the rejected promise means that the promise needs to be re-rejected so that the user's code can have its own error handling and carry on as if the error had not been caught in the first place. 

The original code was re-rejecting the promise by throwing the error. However, throwing an error has a side effect of causing the browser's own devtools to pause when using the "pause on exceptions" feature, because from the browser's perspective this is an uncaught exception - an error has been thrown, and the browser is not concerned about whether this is happening in a promise, or whether the promise rejection is subsequently caught and handled safely. As a result this behaviour can be annoying during development when testing code that should be resilient to promise rejections. However, simply returning a rejected promise (and passing in the error) allows this code to behave exactly the same way but without triggering the browser's "pause on exceptions" behaviour.