### PR TITLE
fix(devtools): fix __VUE_PROD_DEVTOOLS__ defined in cjs build (#1991)

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -27,7 +27,7 @@ function createEntries() {
 function createEntry(config) {
   const isGlobalBuild = config.format === 'iife'
   const isBundlerBuild = config.format !== 'iife' && !config.browser
-  const isBundlerESMBuild = /esm-bundler/.test(format)
+  const isBundlerESMBuild = /esm-bundler/.test(config.format)
 
   const c = {
     external: ['vue'],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -27,7 +27,7 @@ function createEntries() {
 function createEntry(config) {
   const isGlobalBuild = config.format === 'iife'
   const isBundlerBuild = config.format !== 'iife' && !config.browser
-  const isBundlerESMBuild = config.format === 'es'
+  const isBundlerESMBuild = config.format === 'es' && !config.browser
 
   const c = {
     external: ['vue'],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -27,7 +27,7 @@ function createEntries() {
 function createEntry(config) {
   const isGlobalBuild = config.format === 'iife'
   const isBundlerBuild = config.format !== 'iife' && !config.browser
-  const isBundlerESMBuild = /esm-bundler/.test(config.file)
+  const isBundlerESMBuild = config.format === 'es'
 
   const c = {
     external: ['vue'],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -27,7 +27,7 @@ function createEntries() {
 function createEntry(config) {
   const isGlobalBuild = config.format === 'iife'
   const isBundlerBuild = config.format !== 'iife' && !config.browser
-  const isBundlerESMBuild = /esm-bundler/.test(config.format)
+  const isBundlerESMBuild = /esm-bundler/.test(config.file)
 
   const c = {
     external: ['vue'],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -27,6 +27,7 @@ function createEntries() {
 function createEntry(config) {
   const isGlobalBuild = config.format === 'iife'
   const isBundlerBuild = config.format !== 'iife' && !config.browser
+  const isBundlerESMBuild = /esm-bundler/.test(format)
 
   const c = {
     external: ['vue'],
@@ -61,7 +62,9 @@ function createEntry(config) {
     __DEV__: isBundlerBuild
       ? `(process.env.NODE_ENV !== 'production')`
       : config.env !== 'production',
-    __VUE_PROD_DEVTOOLS__: isBundlerBuild ? 'false' : '__VUE_PROD_DEVTOOLS__'
+    __VUE_PROD_DEVTOOLS__: isBundlerESMBuild
+      ? '__VUE_PROD_DEVTOOLS__'
+      : 'false'
   }))
 
   if (config.transpile !== false) {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -61,7 +61,7 @@ function createEntry(config) {
     __DEV__: isBundlerBuild
       ? `(process.env.NODE_ENV !== 'production')`
       : config.env !== 'production',
-    __VUE_PROD_DEVTOOLS__: isBundlerBuild ? '__VUE_PROD_DEVTOOLS__' : 'false'
+    __VUE_PROD_DEVTOOLS__: isBundlerBuild ? 'false' : '__VUE_PROD_DEVTOOLS__'
   }))
 
   if (config.transpile !== false) {


### PR DESCRIPTION
fix #1991
I don't know if I changed it right
But I think __VUE_PROD_DEVTOOLS__ should be replaced to 'false' in the cjs mode.
There should be some small errors here.