### PR TITLE
fix(dispatch): use promise chaining to fix cancelation in bluebird

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -153,15 +153,14 @@ export class Store {
       ? Promise.all(entry.map(handler => handler(payload)))
       : entry[0](payload)
 
-    return new Promise((resolve, reject) => {
-      result.then(res => {
+    return Promise.resolve(result)
+      .then(res => {
         callActionSubscribes('after')
-        resolve(res)
+        return res
       }, error => {
         callActionSubscribes('error', error)
-        reject(error)
+        throw error
       })
-    })
   }
 
   subscribe (fn, options) {


### PR DESCRIPTION
fixes #1993 

Instead of creating a new promise, I'm proposing to use `Promise.resolve` to cast thenable returned by user's action to `Promise` (according to [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/resolve)) and then to chain it with action subscribers. Doing this way will allow Bluebird (if it is used as `Promise` polyfill) to store references between promises for proper cancelation.

Also, I think `slice` should be called also for `after` and `error` to protect users from potentially breaking the iteration over subscribers by calling `unsubscribe` in handlers (the same way as it done for `before`).