### PR TITLE
docs(installation): remove promise polyfill info

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,31 +27,6 @@ npm install vuex@next --save
 yarn add vuex@next --save
 ```
 
-## Promise
-
-Vuex requires [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises). If your supporting browsers do not implement Promise (e.g. IE), you can use a polyfill library, such as [es6-promise](https://github.com/stefanpenner/es6-promise).
-
-You can include it via CDN:
-
-```html
-<script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
-```
-
-Then `window.Promise` will be available automatically.
-
-If you prefer using a package manager such as NPM or Yarn, install it with the following commands:
-
-```bash
-npm install es6-promise --save # NPM
-yarn add es6-promise # Yarn
-```
-
-Furthermore, add the below line into anywhere in your code before using Vuex:
-
-```js
-import 'es6-promise/auto'
-```
-
 ## Dev Build
 
 You will have to clone directly from GitHub and build `vuex` yourself if you want to use the latest dev build.

--- a/docs/ja/installation.md
+++ b/docs/ja/installation.md
@@ -27,31 +27,6 @@ npm install vuex@next --save
 yarn add vuex@next --save
 ```
 
-## Promise
-
-Vuex は [Promise (プロミス)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises) を必要とします。ブラウザで Promise が実装されていない(例 IE)場合は、[es6-promise](https://github.com/stefanpenner/es6-promise) のようなポリフィルライブラリを使用できます。
-
-CDN 経由でそれを含めることができます:
-
-```html
-<script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
-```
-
-`window.Promise` は自動的に有効になります。
-
-NPM または Yarn のようなパッケージマネージャーを使用するのを希望する場合は、以下のコマンドでインストールします:
-
-```bash
-npm install es6-promise --save # NPM
-yarn add es6-promise # Yarn
-```
-
-さらに、Vuex を使用する前に、コードのどこかに次の行を追加します:
-
-```js
-import 'es6-promise/auto'
-```
-
 ## 開発版ビルド
 
 最新の開発版ビルドを利用したい場合には、 GitHub から直接クローンし `vuex` を自身でビルドする必要があります。

--- a/docs/ptbr/installation.md
+++ b/docs/ptbr/installation.md
@@ -27,31 +27,6 @@ npm install vuex@next --save
 yarn add vuex@next --save
 ```
 
-## Promise
-
-Vuex requer [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises). Se os seus navegadores não implementarem o _Promise_ (e.g. IE), você pode usar uma biblioteca _polyfill_, como a [es6-promise](https://github.com/stefanpenner/es6-promise).
-
-Você pode incluí-la via CDN:
-
-```html
-<script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
-```
-
-Então o `window.Promise` estará disponível automaticamente.
-
-Se você preferir usar um gerenciador de pacotes como NPM ou Yarn, instale-o com os seguintes comandos:
-
-```bash
-npm install es6-promise --save # NPM
-yarn add es6-promise # Yarn
-```
-
-Além disso, adicione a linha abaixo em qualquer lugar no seu código antes de usar o Vuex:
-
-```js
-import 'es6-promise/auto'
-```
-
 ## Dev Build
 
 Você terá que clonar diretamente do GitHub e fazer a distribuição (_build_) do `vuex` se

--- a/docs/zh/installation.md
+++ b/docs/zh/installation.md
@@ -27,31 +27,6 @@ npm install vuex@next --save
 yarn add vuex@next --save
 ```
 
-### Promise
-
-Vuex 依赖 [Promise](https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Guide/Using_promises)。如果你支持的浏览器并没有实现 Promise (比如 IE)，那么你可以使用一个 polyfill 的库，例如 [es6-promise](https://github.com/stefanpenner/es6-promise)。
-
-你可以通过 CDN 将其引入：
-
-``` html
-<script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.js"></script>
-```
-
-然后 `window.Promise` 会自动可用。
-
-如果你喜欢使用诸如 npm 或 Yarn 等包管理器，可以按照下列方式执行安装：
-
-``` bash
-npm install es6-promise --save # npm
-yarn add es6-promise # Yarn
-```
-
-或者更进一步，将下列代码添加到你使用 Vuex 之前的一个地方：
-
-``` js
-import 'es6-promise/auto'
-```
-
 ### 自己构建
 
 如果需要使用 dev 分支下的最新版本，您可以直接从 GitHub 上克隆代码并自己构建。


### PR DESCRIPTION
Because Vue 3 doesn't support IE11 anyway, I thought we can remove the info regarding a `Promise` polyfill in the docs ☺️ 
I've removed the paragraph in all available languages