### PR TITLE
Add ActionPayload to ActionHandler payload paramameter

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -109,7 +109,7 @@ export interface StoreOptions<S> {
   devtools?: boolean;
 }
 
-export type ActionHandler<S, R> = (this: Store<R>, injectee: ActionContext<S, R>, payload?: any) => any;
+export type ActionHandler<S, R> = (this: Store<R>, injectee: ActionContext<S, R>, payload?: ActionPayload) => any;
 export interface ActionObject<S, R> {
   root?: boolean;
   handler: ActionHandler<S, R>;


### PR DESCRIPTION
Hello, I noticed, that the second parameter of ```Action``` doesn't have the ActionPayload type.

Cheers