### PR TITLE
feat(types): support optional stricter types for `createStore()`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -68,8 +68,8 @@ export interface ActionContext<S, R> {
   rootGetters: any;
 }
 
-export interface Payload {
-  type: string;
+export interface Payload<Type extends string = string> {
+  type: Type;
 }
 
 export interface MutationPayload extends Payload {
@@ -165,3 +165,213 @@ declare const _default: {
   createLogger: typeof createLogger
 };
 export default _default;
+
+// Stricter Types
+
+export function createStore<Options extends StoreOptions<any>>(
+  options: Options,
+  stricterTypes: true
+): StricterStore<
+  Options extends StoreOptions<infer State> ? State : never,
+  NonNullable<Options["getters"]>,
+  NonNullable<Options["mutations"]>,
+  NonNullable<Options["actions"]>,
+  NonNullable<Options["modules"]>
+>;
+
+export interface StricterStore<
+  RootState,
+  Getters extends GetterTree<RootState, RootState>,
+  Mutations extends MutationTree<RootState>,
+  Actions extends ActionTree<RootState, RootState>,
+  Modules extends ModuleTree<RootState>
+> extends Omit<Store<RootState>, "state" | "getters" | "dispatch" | "commit"> {
+  readonly state: StoreState<RootState, RootState, Modules>;
+  readonly getters: StoreGetters<RootState, RootState, Getters, Modules>;
+
+  dispatch: StricterDispatch<RootState, RootState, Actions, Modules>;
+  commit: StricterCommit<RootState, Mutations, Modules>;
+}
+type StoreState<
+  State,
+  RootState,
+  Modules extends ModuleTree<RootState>
+> = State &
+  {
+    [Name in keyof Modules]: Modules[Name]["state"] &
+      (Modules[Name]["modules"] extends ModuleTree<RootState>
+        ? StoreState<
+            Modules[Name]["state"],
+            RootState,
+            Modules[Name]["modules"]
+          >
+        : {});
+  };
+
+type StoreGetters<
+  State,
+  RootState,
+  Getters extends GetterTree<State, RootState>,
+  Modules extends ModuleTree<RootState>
+> = {
+  [Name in keyof Getters]: ReturnType<Getters[Name]>;
+} &
+  {
+    [Path in ExtractNamespacedPaths<
+      RootState,
+      Modules,
+      "getters"
+    >]: ResolveNamespacedPath<
+      Path,
+      "getters",
+      RootState,
+      Modules
+    > extends infer Getter
+      ? Getter extends () => infer ReturnType
+        ? ReturnType
+        : never
+      : never;
+  };
+
+interface StricterDispatch<
+  State = any,
+  RootState = any,
+  Actions extends ActionTree<State, RootState> = any,
+  Modules extends ModuleTree<RootState> = any
+> {
+  <Type extends DispatchType<State, RootState, Actions, Modules>>(
+    type: Type,
+    payload?: ExtractPayloadType<
+      DispatchAction<State, RootState, Actions, Modules, Type>
+    >,
+    options?: DispatchOptions
+  ): ReturnType<DispatchAction<State, RootState, Actions, Modules, Type>>;
+
+  <Type extends DispatchType<State, RootState, Actions, Modules>>(
+    payloadWithType: Payload<Type> &
+      ExtractPayloadType<
+        DispatchAction<State, RootState, Actions, Modules, Type>
+      >,
+    options?: DispatchOptions
+  ): Promise<any>;
+}
+type DispatchType<
+  State,
+  RootState,
+  Actions extends ActionTree<State, RootState>,
+  Modules extends ModuleTree<RootState>
+> =
+  | (string & keyof Actions)
+  | ExtractNamespacedPaths<RootState, Modules, "actions">;
+type DispatchAction<
+  State,
+  RootState,
+  Actions extends ActionTree<State, RootState>,
+  Modules extends ModuleTree<RootState>,
+  Type extends DispatchType<State, RootState, Actions, Modules>
+> = Type extends string & keyof Actions
+  ? EnsureActionHandler<State, RootState, Actions[Type]>
+  : Type extends ExtractNamespacedPaths<RootState, Modules, "actions">
+  ? ResolveNamespacedPath<
+      Type,
+      "actions",
+      RootState,
+      Modules
+    > extends infer ActionType
+    ? ActionType extends Action<State, RootState>
+      ? EnsureActionHandler<State, RootState, ActionType>
+      : never
+    : never
+  : never;
+type EnsureActionHandler<
+  State,
+  RootState,
+  ActionType extends Action<State, RootState>
+> = ActionType extends ActionObject<State, RootState>
+  ? ActionType["handler"]
+  : ActionType;
+
+export interface StricterCommit<
+  RootState = any,
+  Mutations extends MutationTree<RootState> = any,
+  Modules extends ModuleTree<RootState> = any
+> {
+  <Type extends CommitType<RootState, Mutations, Modules>>(
+    type: Type,
+    payload?: ExtractPayloadType<
+      CommitMutation<RootState, Mutations, Modules, Type>
+    >,
+    options?: CommitOptions
+  ): void;
+
+  <Type extends CommitType<RootState, Mutations, Modules>>(
+    payloadWithType: Payload<Type> &
+      ExtractPayloadType<CommitMutation<RootState, Mutations, Modules, Type>>,
+    options?: CommitOptions
+  ): void;
+}
+type CommitType<
+  RootState,
+  Mutations extends MutationTree<RootState>,
+  Modules extends ModuleTree<RootState>
+> =
+  | (string & keyof Mutations)
+  | ExtractNamespacedPaths<RootState, Modules, "mutations">;
+type CommitMutation<
+  RootState,
+  Mutations extends MutationTree<RootState>,
+  Modules extends ModuleTree<RootState>,
+  Type extends CommitType<RootState, Mutations, Modules>
+> = Type extends string & keyof Mutations
+  ? Mutations[Type]
+  : Type extends ExtractNamespacedPaths<RootState, Modules, "mutations">
+  ? ResolveNamespacedPath<
+      Type,
+      "mutations",
+      RootState,
+      Modules
+    > extends infer MutationType
+    ? MutationType extends Mutation<any>
+      ? MutationType
+      : never
+    : never
+  : never;
+
+type ExtractPayloadType<
+  T extends (_: any, payload: any, ...args: any[]) => any
+> = Parameters<T>[1];
+
+type ExtractNamespacedPaths<
+  RootState,
+  Modules extends ModuleTree<RootState>,
+  KeysFrom extends keyof Module<unknown, unknown>
+> = {
+  [Name in string & keyof Modules]: Modules[Name]["namespaced"] extends true
+    ?
+        | `${Name}/${string & keyof Modules[Name][KeysFrom]}`
+        | `${Name}/${Modules[Name]["modules"] extends ModuleTree<RootState>
+            ? ExtractNamespacedPaths<
+                RootState,
+                Modules[Name]["modules"],
+                KeysFrom
+              >
+            : never}`
+    : never;
+} extends infer T
+  ? T[keyof T]
+  : never;
+type ResolveNamespacedPath<
+  Path extends string,
+  KeysFrom extends keyof Module<unknown, unknown>,
+  RootState,
+  Modules extends ModuleTree<RootState>
+> = Path extends `${infer ModuleName}/${infer RestPathOrKey}`
+  ? RestPathOrKey extends keyof Modules[ModuleName][KeysFrom]
+    ? Modules[ModuleName][KeysFrom][RestPathOrKey]
+    : ResolveNamespacedPath<
+        RestPathOrKey,
+        KeysFrom,
+        RootState,
+        NonNullable<Modules[ModuleName]["modules"]>
+      >
+  : never;

--- a/types/test/index.ts
+++ b/types/test/index.ts
@@ -1,6 +1,57 @@
 import { InjectionKey } from "vue";
 import * as Vuex from "../index";
 
+namespace StricterStoreInstance {
+  const store = Vuex.createStore(
+    {
+      state: { state1: 1 },
+      getters: { getter1: () => 1 },
+      mutations: { mutation1: (state, payload: { a: string }) => {} },
+      actions: { action1: async (context, payload: { a: string }) => 1 },
+      modules: {
+        module1: {
+          namespaced: true,
+          state: { state2: "" },
+          getters: { getter2: () => "" },
+          mutations: { mutation2: (state, payload: { b: number }) => {} },
+          actions: { action2: async (context, payload: { b: number }) => "" },
+          modules: {
+            module2: {
+              namespaced: false,
+              state: { state3: true },
+              getters: { getter3: () => true },
+              mutations: { mutation3: (state, payload: { c: boolean }) => {} },
+              actions: {
+                action3: async (context, payload: { c: boolean }) => true,
+              },
+            },
+          },
+        },
+      },
+    },
+    true
+  );
+
+  const state1 = store.state.state1;
+  const state2 = store.state.module1.state2;
+  const state3 = store.state.module1.module2.state3;
+
+  const getter1 = store.getters.getter1;
+  const getter2 = store.getters["module1/getter2"];
+
+  let commitResult1 = store.commit("mutation1", { a: "" });
+  let commitResult2 = store.commit("module1/mutation2", { b: 1 });
+
+  commitResult1 = store.commit({ type: "mutation1", a: "" });
+  commitResult2 = store.commit({ type: "module1/mutation2", b: 1 });
+
+  let dispatchResult1 = store.dispatch("action1", { a: "" });
+  let dispatchResult2 = store.dispatch("module1/action2", { b: 1 });
+
+  dispatchResult1 = store.dispatch({ type: "action1", a: "" });
+  dispatchResult2 = store.dispatch({ type: "module1/action2", b: 1 });
+}
+
 namespace StoreInstance {
   const store = new Vuex.Store({
     state: {


### PR DESCRIPTION
This is a fully compatible **type-only** feature which is able to greatly improve the development experience!

It added a type-only second parameter `stricterTypes`:

```ts
const store = createStore(
  {
    // ...
  },
  true // <--- set the type-only parameter `stricterTypes` to `true`
);
```

Then, the `store` object's type will be `StricterStore<...>`, which provides a lot of exciting type features:

- `store.state` now contains the state of all the modules
  ```ts
  store.state.module1.module2.deepState;
  ```
- `store.getters` is now strictly typed, it not only contains the types of the root getters but also the ones in **namespaced** (`namespaced: true`) modules
  ```ts
  store.getters["module1/module2/deepGetter"]; // auto-completion supported
  ```
- `store.commit()` and `store.dispatch()` are super intelligent now, the first paremeter `type` supports auto-completion of the paths to both the root mutations/actions and the ones in **namespaced** modules, and the type of the second parameter `payload` will be the same as the type of the second parameter of the target mutation/action. Whatsmore, the return type of `store.dispath` will be the same as the return type of the target action. Ofcourse it supports both `(type, payload, options)` and `(payloadWithType, options)`

The second parameter `stricterTypes` can be removed in later versions if the `StricterStore` type is stable enough.
