### PR TITLE
Update typescript-support.md

### DIFF
--- a/docs/guide/typescript-support.md
+++ b/docs/guide/typescript-support.md
@@ -12,7 +12,6 @@ To do so, declare custom typings for Vue's `ComponentCustomProperties` by adding
 
 ```ts
 // vuex.d.ts
-import { ComponentCustomProperties } from 'vue'
 import { Store } from 'vuex'
 
 declare module '@vue/runtime-core' {


### PR DESCRIPTION
'ComponentCustomProperties' is defined but never used