### PR TITLE
Fix deprecated warning in package.json export module (fix #2047)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
       "require": "./dist/vuex.common.js",
       "import": "./dist/vuex.mjs"
     },
+    "./*": "./*",
     "./": "./"
   },
   "module": "dist/vuex.esm.js",


### PR DESCRIPTION
As mentioned in #2047 

Using the `"./": "./"` is being deprecated and it should be changed to `"./*": "./*"` in the future.
Adding both to the `package.json` will make it ready for the deprecation and remove the `DeprecationWarning` in the current version.