### PR TITLE
typescript enhanced: better Intelligent perception and TS checks

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -9,18 +9,18 @@ import { createLogger } from "./logger";
 export * from "./helpers";
 export * from "./logger";
 
-export declare class Store<S> {
-  constructor(options: StoreOptions<S>);
+export declare class Store<S, Opt extends StoreOptions<S> = Obj > {
+  constructor(options: Opt);
 
-  readonly state: S;
-  readonly getters: any;
 
   install(app: App, injectKey?: InjectionKey<Store<any>> | string): void;
 
   replaceState(state: S): void;
 
-  dispatch: Dispatch;
-  commit: Commit;
+  readonly getters: AllGetter<Opt>
+  readonly state: AllState<Opt>
+  dispatch: AllDispatch<Opt>
+  commit: AllCommit<Opt>
 
   subscribe<P extends MutationPayload>(fn: (mutation: P, state: S) => any, options?: SubscribeOptions): () => void;
   subscribeAction<P extends ActionPayload>(fn: SubscribeActionOptions<P, S>, options?: SubscribeOptions): () => void;
@@ -44,10 +44,60 @@ export declare class Store<S> {
 }
 
 export const storeKey: string;
+type ExStoreOptions<Opt extends StoreOptions<any>, S> = StoreOptions<S> & Opt
 
-export function createStore<S>(options: StoreOptions<S>): Store<S>;
+export function createStore<S, Opt>(options: ExStoreOptions<Opt, S>): Store<S,Opt>;
 
-export function useStore<S = any>(injectKey?: InjectionKey<Store<S>> | string): Store<S>;
+export function useStore<S = any>(injectKey?: InjectionKey<S> | string): S;
+type Obj<T = any> = Record<string, T>
+
+type AddPrefix<Keys, Prefix = ''> = `${Prefix & string}${Prefix extends '' ? '' : '/'}${Keys & string}`
+type AddNs<K, P, N> = N extends { namespaced: boolean } ? (N['namespaced'] extends true ? AddPrefix<K, P> : P) : P
+type GetParam<F> = F extends (context: any, ...params: infer P) => infer R ? [P, R] : never
+
+type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void
+  ? I extends Obj
+    ? I
+    : never
+  : never
+
+type AllState<Opt> = (Opt extends { state: infer S } ? Readonly<S extends () => infer P ? P : S> : undefined) &
+  (Opt extends { modules: infer SubM }
+    ? Readonly<
+        {
+          [K in keyof SubM]: AllState<SubM[K]>
+        }
+      >
+    : unknown)
+
+type GetMap<Opt, Target extends string, Pre = ''> = UnionToIntersection<
+  | (Opt extends { [_ in Target]: infer MM }
+      ? {
+          [K in keyof MM as AddPrefix<K, Pre>]: GetParam<MM[K]>
+        }
+      : never)
+  | GetModulesMap<Opt, Target, Pre>
+>
+
+type GetModulesMap<Opt, Target extends string, Pre = ''> = Opt extends { modules: infer SubM }
+  ? {
+      [K in keyof SubM]: GetMap<SubM[K], Target, AddNs<K, Pre, SubM[K]>>
+    }[keyof SubM]
+  : never
+
+type AllGetter<Opt, G extends Obj = GetMap<Opt, 'getters'>> = {
+  readonly [K in keyof G]: G[K][1]
+}
+type AllCommit<Opt, G extends Obj = GetMap<Opt, 'mutations'>> = {
+  <K extends keyof G>(
+    type: K,
+    ...payload: [...a: G[K][0] extends [] ? [payload?: null] : G[K][0], options?: CommitOptions]
+  ): void
+  // <S extends { type: keyof G }>(payloadWithType: S, options?: CommitOptions): void
+}
+type AllDispatch<Opt, G extends Obj = GetMap<Opt, 'actions'>> = {
+  <S extends keyof G>(type: S, ...payload: G[S][0]): Promise<G[S][1]>
+}
 
 export interface Dispatch {
   (type: string, payload?: any, options?: DispatchOptions): Promise<any>;


### PR DESCRIPTION
Better intelligent prompt and TS checks and without affecting functions already supported by TS.
+ Enhance `state`, `getters` infinite hierarchical property hints, and support read-only checks.
+ Enhanced `commit`, `dispatch` methods sense all operational type names and check payload parameters.
+ Support the 'namespaced' attribute configuration to automatically generate 'type' parameter names.

**Unsupported actions:**
1. does not support object-style commit or dispatch because there is no limit to the payload must be object type
2. does not support  register global action in namespaced modules, this usage is not recommended
3. does not support dynamic registration of the module, need to use `(store.dispatch as any) ('doSomething') ` way to skip detection,

**Incompatible usage methods:**
1. `createStore<State>({...})`  
The type specified through generics cannot be supported because all configuration items need to be passed!    
Instead of manually specifying `<State>`, the default will automatically infer from the state option; When you need a custom type, use `class` to define and set the initial value, and then create an instance in the state configuration item;

  ```ts
  class State {
    name = ''
    count = 1
    list:string[] = []
  }
  const store = createStore({
    state: new State(),
    ...
  }
  ```

2. `const key: InjectionKey<Store<State>> = Symbol()`  
The current store type needs to use the `<typeof store >` way

3. global type supplement

``` ts
import { store } from '.. /src/store'

interface InjectionMap {
  'store': typeof store
}

declare module '@vue/runtime-core' {

  interface ComponentCustomProperties {
    $store: InjectionMap['store']
  }
  export function inject<S extends keyof InjectionMap>(key:S):InjectionMap[S]
}
```

更好的提供感知提示及TS校验，在不影响已有TS支持的功能情况下， 增强 state, getters 无限层级属性提示，并支持只读校验； 增强 commit、dispatch 方法感知所有操作类型名称并对载荷参数校验，类型名称支持namespaced配置进行拼接。

不支持的操作：  
1、不支持对象方式分发或提交，因为没有限制载荷必须为对象类型
2、不支持在带命名空间的模块注册全局 action，不推荐这种用法
3、不支持动态注册的模块， 需要使用 ` (store.dispatch as any)('doSomething')` 的方式来跳过检测

![image](https://github.com/nicefan/vuex-ts-enhanced/raw/master/effect.webp)