### PR TITLE
feat: add named export in cjs format file

### DIFF
--- a/src/index.cjs.js
+++ b/src/index.cjs.js
@@ -16,3 +16,16 @@ export default {
   createNamespacedHelpers,
   createLogger
 }
+
+export {
+  Store,
+  storeKey,
+  createStore,
+  useStore,
+  mapState,
+  mapMutations,
+  mapGetters,
+  mapActions,
+  createNamespacedHelpers,
+  createLogger
+}


### PR DESCRIPTION
`export default` has many bugs when used with `commonjs`, `vuex` use export default object in `vuex.cjs.js` which is not like `vue-router-next`. It cause the below code cannot get correct value in the lastest vite version

```js
import { createStore } from 'vuex'
console.log(createStore === undefined)
```