### PR TITLE
Define state when preserved is true, but there is nothing to preserve

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -354,16 +354,14 @@ function installModule (store, rootState, path, module, hot) {
       }
       Vue.set(parentState, moduleName, module.state)
     })
-  }
-  else{
-    //set state when preserved/hot is true, but no state for modules were register before
-      if(! (moduleName in parentState) ){
-        store._withCommit(function () {
-          Vue.set(rootState, moduleName, module.state);
-        });
-      }
+  } else {
+    if( !parentState || !(moduleName in parentState) ){
+      store._withCommit(function () {
+        Vue.set(rootState, moduleName, module.state);
+      });
     }
-
+  }
+  
   const local = module.context = makeLocalContext(store, namespace, path)
 
   module.forEachMutation((mutation, key) => {

--- a/src/store.js
+++ b/src/store.js
@@ -343,7 +343,7 @@ function installModule (store, rootState, path, module, hot) {
   const parentState = getNestedState(rootState, path.slice(0, -1))
   const moduleName = path[path.length - 1]
   // set state
-  if (!isRoot && !hot) {    
+  if (!isRoot && !hot) {
     store._withCommit(() => {
       if (__DEV__) {
         if (moduleName in parentState) {
@@ -355,10 +355,10 @@ function installModule (store, rootState, path, module, hot) {
       Vue.set(parentState, moduleName, module.state)
     })
   } else {
-    if( !parentState || !(moduleName in parentState) ){
+    if (moduleName && (!parentState || !(moduleName in parentState))) {
       store._withCommit(function () {
-        Vue.set(rootState, moduleName, module.state);
-      });
+        Vue.set(rootState, moduleName, module.state)
+      })
     }
   }
   

--- a/src/store.js
+++ b/src/store.js
@@ -340,10 +340,10 @@ function installModule (store, rootState, path, module, hot) {
     store._modulesNamespaceMap[namespace] = module
   }
 
+  const parentState = getNestedState(rootState, path.slice(0, -1))
+  const moduleName = path[path.length - 1]
   // set state
-  if (!isRoot && !hot) {
-    const parentState = getNestedState(rootState, path.slice(0, -1))
-    const moduleName = path[path.length - 1]
+  if (!isRoot && !hot) {    
     store._withCommit(() => {
       if (__DEV__) {
         if (moduleName in parentState) {
@@ -355,6 +355,14 @@ function installModule (store, rootState, path, module, hot) {
       Vue.set(parentState, moduleName, module.state)
     })
   }
+  else{
+    //set state when preserved/hot is true, but no state for modules were register before
+      if(! (moduleName in parentState) ){
+        store._withCommit(function () {
+          Vue.set(rootState, moduleName, module.state);
+        });
+      }
+    }
 
   const local = module.context = makeLocalContext(store, namespace, path)
 

--- a/src/store.js
+++ b/src/store.js
@@ -361,7 +361,7 @@ function installModule (store, rootState, path, module, hot) {
       })
     }
   }
-  
+
   const local = module.context = makeLocalContext(store, namespace, path)
 
   module.forEachMutation((mutation, key) => {


### PR DESCRIPTION
Vuex handles modules defined in the constructor options different from those registered with store.registerModule. For registerModule calls, the modules pass for a variety of checks before being embedded in the global store.

When checking in "installModule" if the module should be at the root and if the "state" should not be preserved is not observed that if "hot" is set to true, but the state was not defined before throws an error inside the mutation called to change state like "Cannot read properties of undefined (reading 'foo')".

That occurs because it was preserved a no existing state. That's why we should check if the state already exists if so, it will be preserved otherwise we set the default from the module. 

The fast way to verify this bug is creating a project from scratch, adding vuex, creating a module (I did it in a separate file), setting the namespace to true, registering it like "store.registerModule('bar', module, {preserveState:true})". Now at a vue file call from a a method "this.$store.dispatch('bar/setValue', {name:'foo'})".

Fixes #2083