### PR TITLE
Updated Installation docs for Vue CLI Installation

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -21,6 +21,14 @@ Include `vuex` after Vue and it will install itself automatically:
 npm install vuex@next --save
 ```
 
+## Vue CLI
+
+If you have a project using [Vue CLI](https://cli.vuejs.org/) you can add Vuex as a plugin. **It will also overwrite your `App.vue`** so make sure to backup the file before running the following command inside your project:
+
+```bash
+vue add vuex
+```
+
 ## Yarn
 
 ```bash


### PR DESCRIPTION
The current docs don't include information about installing Vuex through the Vue CLI. I couldn't find information on the Vue CLI docs about Vuex, so I figured I'd add it here. I also copied the installation text from the [Vue router docs](https://router.vuejs.org/installation.html#direct-download-cdn) to keep it consistent.