### PR TITLE
Make vuex usable in react, react-native

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.log
 .DS_Store
 node_modules
+.idea

--- a/package.json
+++ b/package.json
@@ -56,7 +56,10 @@
     "vue": "^3.2.0"
   },
   "dependencies": {
-    "@vue/devtools-api": "^6.0.0-beta.11"
+    "@vue/devtools-api": "^6.0.0-beta.11",
+    "@vue/reactivity": "^3.2.31",
+    "@vue/runtime-core": "^3.2.31",
+    "@vue/shared": "^3.2.31"
   },
   "devDependencies": {
     "@babel/core": "^7.14.3",

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,4 +1,5 @@
 import { isObject } from './util'
+import {getGlobalThis} from "@vue/shared";
 
 /**
  * Reduce the code which written in Vue.js for getting the state.
@@ -7,16 +8,17 @@ import { isObject } from './util'
  * @param {Object}
  */
 export const mapState = normalizeNamespace((namespace, states) => {
+  const globalThis= getGlobalThis()
   const res = {}
   if (__DEV__ && !isValidMap(states)) {
     console.error('[vuex] mapState: mapper parameter must be either an Array or an Object')
   }
   normalizeMap(states).forEach(({ key, val }) => {
     res[key] = function mappedState () {
-      let state = this.$store.state
-      let getters = this.$store.getters
+      let state = globalThis.$store.state
+      let getters = globalThis.$store.getters
       if (namespace) {
-        const module = getModuleByNamespace(this.$store, 'mapState', namespace)
+        const module = getModuleByNamespace(globalThis.$store, 'mapState', namespace)
         if (!module) {
           return
         }
@@ -40,6 +42,7 @@ export const mapState = normalizeNamespace((namespace, states) => {
  * @return {Object}
  */
 export const mapMutations = normalizeNamespace((namespace, mutations) => {
+  const globalThis= getGlobalThis()
   const res = {}
   if (__DEV__ && !isValidMap(mutations)) {
     console.error('[vuex] mapMutations: mapper parameter must be either an Array or an Object')
@@ -47,9 +50,9 @@ export const mapMutations = normalizeNamespace((namespace, mutations) => {
   normalizeMap(mutations).forEach(({ key, val }) => {
     res[key] = function mappedMutation (...args) {
       // Get the commit method from store
-      let commit = this.$store.commit
+      let commit = globalThis.$store.commit
       if (namespace) {
-        const module = getModuleByNamespace(this.$store, 'mapMutations', namespace)
+        const module = getModuleByNamespace(globalThis.$store, 'mapMutations', namespace)
         if (!module) {
           return
         }
@@ -70,6 +73,7 @@ export const mapMutations = normalizeNamespace((namespace, mutations) => {
  * @return {Object}
  */
 export const mapGetters = normalizeNamespace((namespace, getters) => {
+  const globalThis= getGlobalThis()
   const res = {}
   if (__DEV__ && !isValidMap(getters)) {
     console.error('[vuex] mapGetters: mapper parameter must be either an Array or an Object')
@@ -78,14 +82,14 @@ export const mapGetters = normalizeNamespace((namespace, getters) => {
     // The namespace has been mutated by normalizeNamespace
     val = namespace + val
     res[key] = function mappedGetter () {
-      if (namespace && !getModuleByNamespace(this.$store, 'mapGetters', namespace)) {
+      if (namespace && !getModuleByNamespace(globalThis.$store, 'mapGetters', namespace)) {
         return
       }
-      if (__DEV__ && !(val in this.$store.getters)) {
+      if (__DEV__ && !(val in globalThis.$store.getters)) {
         console.error(`[vuex] unknown getter: ${val}`)
         return
       }
-      return this.$store.getters[val]
+      return globalThis.$store.getters[val]
     }
     // mark vuex getter for devtools
     res[key].vuex = true
@@ -100,6 +104,7 @@ export const mapGetters = normalizeNamespace((namespace, getters) => {
  * @return {Object}
  */
 export const mapActions = normalizeNamespace((namespace, actions) => {
+  const globalThis= getGlobalThis()
   const res = {}
   if (__DEV__ && !isValidMap(actions)) {
     console.error('[vuex] mapActions: mapper parameter must be either an Array or an Object')
@@ -107,9 +112,9 @@ export const mapActions = normalizeNamespace((namespace, actions) => {
   normalizeMap(actions).forEach(({ key, val }) => {
     res[key] = function mappedAction (...args) {
       // get dispatch function from store
-      let dispatch = this.$store.dispatch
+      let dispatch = globalThis.$store.dispatch
       if (namespace) {
-        const module = getModuleByNamespace(this.$store, 'mapActions', namespace)
+        const module = getModuleByNamespace(globalThis.$store, 'mapActions', namespace)
         if (!module) {
           return
         }
@@ -117,7 +122,7 @@ export const mapActions = normalizeNamespace((namespace, actions) => {
       }
       return typeof val === 'function'
         ? val.apply(this, [dispatch].concat(args))
-        : dispatch.apply(this.$store, [val].concat(args))
+        : dispatch.apply(globalThis.$store, [val].concat(args))
     }
   })
   return res

--- a/src/injectKey.js
+++ b/src/injectKey.js
@@ -1,4 +1,4 @@
-import { inject } from 'vue'
+import { inject } from '@vue/runtime-core'
 
 export const storeKey = 'store'
 

--- a/src/store-util.js
+++ b/src/store-util.js
@@ -1,4 +1,5 @@
-import { reactive, computed, watch, effectScope } from 'vue'
+import { reactive, computed, effectScope } from '@vue/reactivity'
+import { watch } from '@vue/runtime-core'
 import { forEachValue, isObject, isPromise, assert, partial } from './util'
 
 export function genericSubscribe (fn, subs, options) {

--- a/src/store.js
+++ b/src/store.js
@@ -1,4 +1,4 @@
-import { watch } from 'vue'
+import { watch } from '@vue/runtime-core'
 import { storeKey } from './injectKey'
 import { addDevtools } from './plugins/devtool'
 import ModuleCollection from './module/module-collection'


### PR DESCRIPTION
Using Vuex outside of Vue projects looks possible with a few simple changes. Vuex works independently only using few imports from `@vue/reactivity` and `@vue/runtime-core`. Switching these to pure imports removes the need to import them through Vue. 

Additionally, component binding helpers `mapXXX`, `createNamespacedHelpers` only presume `this.$store` is accessible. Switching `this` to `globalThis` from `@vue/shared` allows `this` to be flexibly determined by runtime Javascript's [globalThis](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis).

@yyx990803, @ktsn, @kiaking - I have managed to use Vuex store successfully in a react-native project after making these changes. The best part is it works according to Vuex documentation. 

It will great if these changes make it to mainline branch. Love to use Vuex over other state management libraries in React ecosystem.