### PR TITLE
docs(ja): fix the translation of the description of hasModule method.

### DIFF
--- a/docs/ja/api/index.md
+++ b/docs/ja/api/index.md
@@ -264,8 +264,7 @@ sidebar: auto
 ### hasModule
 
 - `hasModule(path: string | Array<string>): boolean`
-
-  動的なモジュールがすでに登録されているかどうかを確認します。[詳細](../guide/modules.md#dynamic-module-registration)
+  渡された名前を持つモジュールがすでに登録されているかどうかを確認します。[詳細](../guide/modules.md#dynamic-module-registration)
 
 ### hotUpdate
 


### PR DESCRIPTION
'Check if the module with the given name is already registered.'の翻訳を修正

原文にはない「動的なモジュール」を「モジュール」に修正しました。