### PR TITLE
fix：error in Vuex document link

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -36,7 +36,7 @@ module.exports = {
   themeConfig: {
     repo: 'vuejs/vuex',
     docsDir: 'docs',
-    docsBranch: '4.0',
+    docsBranch: 'main',
 
     editLinks: true,
 


### PR DESCRIPTION
Vuex's document, edit this page on GitHub, link to error.
This bug comes from the configuration issue with VuePress. The original configured document branch was 4.0, but this branch is no longer visible. 
This pr changed it to the default branch.

issue : https://github.com/vuejs/vuex/issues/2230