### PR TITLE
Vuex Devtools plugins registered on server which increases memory usage

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -12,6 +12,8 @@ import {
   unifyObjectStyle
 } from './store-util'
 
+const isBrowser = typeof document !== 'undefined'
+
 export function createStore (options) {
   return new Store(options)
 }
@@ -73,9 +75,9 @@ export class Store {
     app.provide(injectKey || storeKey, this)
     app.config.globalProperties.$store = this
 
-    const useDevtools = this._devtools !== undefined
+    const useDevtools = (this._devtools !== undefined
       ? this._devtools
-      : __DEV__ || __VUE_PROD_DEVTOOLS__
+      : __DEV__ || __VUE_PROD_DEVTOOLS__) && isBrowser
 
     if (useDevtools) {
       addDevtools(app, this)


### PR DESCRIPTION
Fixes #2250

- Add check that code is running in a browser before adding devtools

Would need this fix for 4.0.2 since I cannot upgrade to 4.1.0 due to bugs with deregistering modules at runtime.