### PR TITLE
docs: augment `vue` rather than `@vue/runtime-core`

### DIFF
--- a/docs/guide/migrating-to-4-0-from-3-x.md
+++ b/docs/guide/migrating-to-4-0-from-3-x.md
@@ -58,7 +58,7 @@ Place the following code in your project to allow `this.$store` to be typed corr
 import { ComponentCustomProperties } from 'vue'
 import { Store } from 'vuex'
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   // Declare your own store states.
   interface State {
     count: number

--- a/docs/guide/typescript-support.md
+++ b/docs/guide/typescript-support.md
@@ -14,7 +14,7 @@ To do so, declare custom typings for Vue's `ComponentCustomProperties` by adding
 // vuex.d.ts
 import { Store } from 'vuex'
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   // declare your own store states
   interface State {
     count: number

--- a/docs/ja/guide/migrating-to-4-0-from-3-x.md
+++ b/docs/ja/guide/migrating-to-4-0-from-3-x.md
@@ -58,7 +58,7 @@ Vuex 4 は、[issue #994](https://github.com/vuejs/vuex/issues/994) を解決す
 import { ComponentCustomProperties } from 'vue'
 import { Store } from 'vuex'
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   // ストアのステートを宣言する
   interface State {
     count: number

--- a/docs/ja/guide/typescript-support.md
+++ b/docs/ja/guide/typescript-support.md
@@ -15,7 +15,7 @@ Vuex はすぐに使用できる `this.$store` プロパティの型付けを提
 import { ComponentCustomProperties } from 'vue'
 import { Store } from 'vuex'
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   // ストアのステートを宣言する
   interface State {
     count: number

--- a/docs/ptbr/guide/migrating-to-4-0-from-3-x.md
+++ b/docs/ptbr/guide/migrating-to-4-0-from-3-x.md
@@ -58,7 +58,7 @@ Coloque o seguinte código em seu projeto para permitir que `this.$store` seja t
 import { ComponentCustomProperties } from 'vue'
 import { Store } from 'vuex'
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   // Declare seus próprios estados do store
   interface State {
     count: number

--- a/docs/ptbr/guide/typescript-support.md
+++ b/docs/ptbr/guide/typescript-support.md
@@ -15,7 +15,7 @@ Para fazer isso, declare tipagens personalizadas para o `ComponentCustomProperti
 import { ComponentCustomProperties } from 'vue'
 import { Store } from 'vuex'
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   // declare seus próprios estados do store
   interface State {
     count: number

--- a/docs/zh/guide/migrating-to-4-0-from-3-x.md
+++ b/docs/zh/guide/migrating-to-4-0-from-3-x.md
@@ -58,7 +58,7 @@ app.mount('#app')
 import { ComponentCustomProperties } from 'vue'
 import { Store } from 'vuex'
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   // 声明自己的 store state
   interface State {
     count: number

--- a/docs/zh/guide/typescript-support.md
+++ b/docs/zh/guide/typescript-support.md
@@ -14,7 +14,7 @@ Vuex 没有为 `this.$store` 属性提供开箱即用的类型声明。如果你
 // vuex.d.ts
 import { Store } from 'vuex'
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   // 声明自己的 store state
   interface State {
     count: number


### PR DESCRIPTION
https://github.com/nuxt/nuxt/issues/28373#issuecomment-2373531197

This updates the docs to use the currently recommended way to augment component custom properties in Vue 3.