### PR TITLE
fix: augment vue rather than @vue/runtime-core

### DIFF
--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -5,7 +5,7 @@
 import { ComponentCustomOptions } from "vue";
 import { Store } from "./index";
 
-declare module "@vue/runtime-core" {
+declare module "vue" {
   interface ComponentCustomOptions {
     store?: Store<any>;
   }


### PR DESCRIPTION
Follow new way to augmenting global properties

https://vuejs.org/guide/typescript/options-api.html#augmenting-global-properties