### PR TITLE
remove old watchers on strict mode (fix #2260)

### DIFF
--- a/src/store-util.js
+++ b/src/store-util.js
@@ -269,7 +269,8 @@ function registerGetter (store, type, rawGetter, local) {
 }
 
 function enableStrictMode (store) {
-  watch(() => store._state.data, () => {
+  store._strictModeWatcherUnsubscribe && store._strictModeWatcherUnsubscribe();
+  store._strictModeWatcherUnsubscribe = watch(() => store._state.data, () => {
     if (__DEV__) {
       assert(store._committing, `do not mutate vuex store state outside mutation handlers.`)
     }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-import { App, WatchOptions, InjectionKey } from "vue";
+import { App, WatchOptions, InjectionKey , WatchStopHandle } from "vue";
 
 // augment typings of Vue.js
 import "./vue";
@@ -41,6 +41,8 @@ export declare class Store<S> {
     getters?: GetterTree<S, S>;
     modules?: ModuleTree<S>;
   }): void;
+
+  _strictModeWatcherUnsubscribe?: WatchStopHandle;
 }
 
 export const storeKey: string;


### PR DESCRIPTION
This fix tries to correct the issue (https://github.com/vuejs/vuex/issues/2260) when using strict mode, it creates multiple watchers and never stops them.

I added a property on the Store that will keep the last strict mode watcher and remove it before creating one